### PR TITLE
Sqlite as psql fallback for testing

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,12 @@
+TESTING=true
+DB_URI=sqlite:///:memory:
+S3_ACCESS_KEY=lenny
+S3_SECRET_KEY=lennytesting
+MINIO_BUCKET=lenny
+MINIO_HOST=localhost
+MINIO_PORT=9000
+POSTGRES_HOST=localhost
+POSTGRES_USER=lenny
+POSTGRES_PASSWORD=lennytest
+POSTGRES_PORT=5432
+POSTGRES_DB=lending_system

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,13 +6,13 @@ services:
       dockerfile: docker/Dockerfile
     container_name: lenny_api
     ports:
-      - "8080:80"  # Changed from 7000:7000 to avoid port conflict (nginx api)
+      - "8080:80"  
     depends_on:
       - db
       - s3
     env_file: lenny.env
     environment:
-    - LENNY_PORT=1337  # When in docker, run Lenny as 1337, reverse proxies from nginx
+    - LENNY_PORT=1337  
     networks:
       - lenny_network
 
@@ -29,7 +29,7 @@ services:
       - lenny_network
 
   s3:
-    image: minio/minio
+    image: minio/minio:latest
     container_name: lenny_bookshelf
     env_file: lenny.env
     ports:

--- a/lenny/configs/__init__.py
+++ b/lenny/configs/__init__.py
@@ -8,13 +8,19 @@
 """
 
 import os
+from dotenv import load_dotenv
+
+# Load environment variables from .env.test file
+load_dotenv(dotenv_path=".env.test", override= True)
+
+TESTING = os.environ.get("TESTING", "False").lower() == "true"
 
 # API server configuration
 DOMAIN = os.environ.get('LENNY_DOMAIN', '127.0.0.1')
 HOST = os.environ.get('LENNY_HOST', '0.0.0.0')
 PORT = int(os.environ.get('LENNY_PORT', 8080))
 WORKERS = int(os.environ.get('LENNY_WORKERS', 1))
-DEBUG = bool(int(os.environ.get('LENNY_DEBUG', 1)))
+DEBUG = bool(int(os.environ.get('LENNY_DEBUG', 0)))
 
 LOG_LEVEL = os.environ.get('LENNY_LOG_LEVEL', 'info')
 SSL_CRT = os.environ.get('LENNY_SSL_CRT')
@@ -31,25 +37,27 @@ if SSL_CRT and SSL_KEY:
     OPTIONS['ssl_keyfile'] = SSL_KEY
     OPTIONS['ssl_certfile'] = SSL_CRT
 
-# Database configuration - prioritize environment variables 
-DB_CONFIG = {
-    'user': os.environ.get('POSTGRES_USER', 'postgres'),
-    'password': os.environ.get('POSTGRES_PASSWORD'),
-    'host': os.environ.get('POSTGRES_HOST', 'localhost'),
+# Database configuration
+if TESTING:
+    DB_URI = "sqlite:///:memory:"
+else:
+    DB_CONFIG = {
+    'user': os.environ.get('POSTGRES_USER', 'lenny'),
+    'password': os.environ.get('POSTGRES_PASSWORD', 'lennytest'),
+    'host': os.environ.get('POSTGRES_HOST', 'postgres'),
     'port': int(os.environ.get('POSTGRES_PORT', '5432')),
-    'dbname': os.environ.get('POSTGRES_DB', 'lenny'),
-}
+    'dbname': os.environ.get('POSTGRES_DB', 'lending_system'),
+    }
+    DB_URI = 'postgresql+psycopg2://{user}:{password}@{host}:{port}/{dbname}'.format(**DB_CONFIG) 
 
-DB_URI = 'postgres://%(user)s:%(password)s@%(host)s:%(port)s/%(dbname)s' % DB_CONFIG
-
-# MinIO configuration - prioritize environment variables
+# MinIO configuration
 S3_CONFIG = {
-    'user': os.environ.get('MINIO_ROOT_USER'),
-    'password': os.environ.get('MINIO_ROOT_PASSWORD'),
-    'host': os.environ.get('MINIO_HOST', 'localhost'),
-    'port': int(os.environ.get('MINIO_PORT', '9000')),
+    'access_key': os.environ.get('S3_ACCESS_KEY', os.environ.get('MINIO_ROOT_USER')),
+    'secret_key': os.environ.get('S3_SECRET_KEY', os.environ.get('MINIO_ROOT_PASSWORD')),
+    'endpoint': f"{os.environ.get('MINIO_HOST', 'minio')}:{os.environ.get('MINIO_PORT', '9000')}",
+    'secure': False,
+    'public_bucket': os.environ.get('MINIO_BUCKET', 'lenny') + "-public",
+    'protected_bucket': os.environ.get('MINIO_BUCKET', 'lenny') + "-protected",
 }
 
-# Export all configuration variables
-__all__ = ['config', 'HOST', 'PORT', 'DEBUG', 'OPTIONS', 'DB_CONFIG',
-           'S3_CONFIG']
+__all__ = ['DOMAIN', 'HOST', 'PORT', 'DEBUG', 'OPTIONS', 'DB_URI', 'DB_CONFIG','S3_CONFIG', 'TESTING']

--- a/lenny/models/__init__.py
+++ b/lenny/models/__init__.py
@@ -1,10 +1,32 @@
 #!/usr/bin/env python
+"""
+    Models Configurations for Lenny,
+    including handling database connections and ORM setup.
+
+    :copyright: (c) 2015 by AUTHORS
+    :license: see LICENSE for more details
+"""
 
 from sqlalchemy import create_engine
-from sqlalchemy.orm import scoped_session, sessionmaker
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker, declarative_base
+from lenny.configs import DB_URI, TESTING
 
-from lenny.configs import DB_URI, DEBUG
+Base = declarative_base()
 
-engine = create_engine(DB_URI, echo=DEBUG, client_encoding='utf8')
-db = scoped_session(sessionmaker(bind=engine))
+if TESTING:
+    engine = create_engine("sqlite:///:memory:", connect_args={'check_same_thread': False})
+    Base.metadata.creat_all(bind=engine)
+else:
+    engine = create_engine(DB_URI)
+    
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+def get_db():
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        if TESTING:
+            engine.dispose()
+

--- a/lenny/models/__init__.py
+++ b/lenny/models/__init__.py
@@ -30,3 +30,4 @@ def get_db():
         if TESTING:
             engine.dispose()
 
+__all__ = ["Base", "SessionLocal", "get_db", "engine"]

--- a/lenny/schemas/__init__.py
+++ b/lenny/schemas/__init__.py
@@ -1,0 +1,3 @@
+from typing import Union
+
+__all__ = ["Item"]

--- a/lenny/schemas/item.py
+++ b/lenny/schemas/item.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from sqlalchemy import Column, Integer, String, Boolean
-from lenny.models import, db, Base
+from lenny.models import db, Base
 
 class Item(Base):
     __tablename__ = "items"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+env_files =
+    .env.test

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,8 @@ SQLAlchemy==2.0.39
 psycopg2-binary==2.9.10
 pyyaml==6.0.2
 requests==2.32.3
+python-dotenv==1.1.0
 typing_extensions==4.12.2
 minio==7.2.9
+pytest==7.4.2
+psycopg2==2.9.10

--- a/tests/test_core_items.py
+++ b/tests/test_core_items.py
@@ -10,3 +10,11 @@
     :copyright: (c) 2015 by Authors.
     :license: see LICENSE for more details.
 """
+
+import pytest 
+from lenny.models import get_db,Base
+
+@pytest.fixture
+def db_session():
+    with next(get_db()) as session:
+        Base.metadata.creal_all(bind=session.bind)

--- a/tests/test_core_items.py
+++ b/tests/test_core_items.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+    tests.test_packaging
+    ~~~~~~~~~~~~~~~~~~~~
+
+    This module tests the core items of the Lenny package.
+
+    :copyright: (c) 2015 by Authors.
+    :license: see LICENSE for more details.
+"""


### PR DESCRIPTION
closes #16 

### 
This pull request introduces changes to support a testing environment for the Lenny application, updates configurations for database and MinIO integration, and refactors the codebase to improve maintainability and testing capabilities. Key changes include the addition of a `.env.test` file, updates to `compose.yaml` for container configurations, and modifications to the database and ORM setup to support in-memory SQLite during testing.

### Testing Environment Setup:
* Added `.env.test` file containing environment variables for testing, including SQLite in-memory database configuration and MinIO credentials.
* Updated `lenny/configs/__init__.py` to load environment variables from `.env.test`, enable testing mode via a `TESTING` flag, and configure SQLite as the database backend when testing is enabled. [[1]](diffhunk://#diff-f8c4c724111042e67a1181e60528a066f21154bf133bc676ef96f5ac3256091fR11-R23) [[2]](diffhunk://#diff-f8c4c724111042e67a1181e60528a066f21154bf133bc676ef96f5ac3256091fL34-R63)

### Container Configuration Updates:
* Updated the `compose.yaml` file to use the latest MinIO image and removed redundant comments in the `services` section. [[1]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cL9-R15) [[2]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cL32-R32)

### Database and ORM Refactoring:
* Refactored `lenny/models/__init__.py` to initialize the SQLAlchemy engine and session based on the `TESTING` flag, supporting SQLite in-memory database for tests. Added a `get_db` function for session management.
* Fixed an import issue in `lenny/schemas/item.py` by removing an invalid import statement.

### Testing Enhancements:
* Added a new test file, `tests/test_core_items.py`, with a pytest fixture for database session management during tests.
- [x] Added Sqlite as psql for testing 