### PR TITLE
Refactor Item model to include additional fields and remove ItemSetti…

### DIFF
--- a/lenny/models/items.py
+++ b/lenny/models/items.py
@@ -1,6 +1,24 @@
 #!/usr/bin/env python 
-from pydantic import BaseModel
+from sqlalchemy  import Column, String, Boolean, Integer, DateTime
+from sqlalchemy.sql import func
+from . import Base
 
-class ItemSettings(BaseModel):
-    is_lendable: bool
-    num_lendable_total: int
+class Item(Base):
+    __tablename__ = 'items'
+    
+    lenny_edition = Column(String(100),primary_key=True)
+    title = Column(String(255), nullable=False)
+    item_status = Column(Boolean, default=True)
+    language = Column(String(30), nullable=False)
+    is_readable = Column(Boolean, default=True, nullable=False)
+    is_lendable = Column(Boolean, default= True, nallable= False)
+    is_wishlistable = Column(Boolean, default= True, nullable=False)
+    is_Printdisabled = Column(Boolean, default=False, nullable= False)
+    num_lendable_total = Column(Integer, nullable=False) 
+    current_num_lendable = Column(Integer, nullable=False)
+    current_waitlist_size =Column(Integer, default= 0, nullable=False)
+    encrypted = Column(Boolean, default= False, nullable=False)
+    s3_filepath = Column(String, nullable=False)
+    created_at = Column(DateTime(timezone=True), default=func.now())
+    updated_at = Column(DateTime(timezone=True), default=func.now(), onupdate=func.now())
+    


### PR DESCRIPTION
closes #20 

- [x] Added required fields to store items for the `S3` items

@mekarpeles would like you to have a look at this `Feilds`

- `Lenny_edition` stores the unique values init, like `openlibrary_edition`