### PR TITLE
Pre-loading script for books around 100+

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Lenny is a free, open source Lending System for Libraries.
 ```
 docker/configure.sh  # generates lenny.env
 docker compose -p lenny up -d --build
+python scripts/load_open_books.py # loads books
 ```
 
 Navigate to localhost:8080 or whatever `$LENNY_PORT` you specified in your `lenny.env`

--- a/lenny/core/itemsUpload.py
+++ b/lenny/core/itemsUpload.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session
 from botocore.exceptions import ClientError 
 
 from lenny.models import db
-from lenny.models.items import Item  
+from lenny.models.items import Item, FormatEnum 
 from lenny.core import s3 
 
 def upload_items(openlibrary_edition: int, encrypted: bool, files: list[UploadFile], db_session: Session = db):
@@ -26,6 +26,19 @@ def upload_items(openlibrary_edition: int, encrypted: bool, files: list[UploadFi
             continue 
 
         file_extension = Path(file_upload.filename).suffix.lower()
+        
+        item_format: FormatEnum
+        if file_extension == ".pdf":
+            item_format = FormatEnum.PDF
+        elif file_extension == ".epub":
+            item_format = FormatEnum.EPUB
+        else:
+            
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unsupported file format: '{file_extension}' for file '{file_upload.filename}'. Only '.pdf' and '.epub' are supported."
+            )
+
         s3_object_name = f"{openlibrary_edition}{file_extension}"
         
         try:
@@ -43,7 +56,8 @@ def upload_items(openlibrary_edition: int, encrypted: bool, files: list[UploadFi
             new_item = Item(
                 openlibrary_edition=openlibrary_edition,
                 encrypted=encrypted,
-                s3_filepath=s3_filepath
+                s3_filepath=s3_filepath,
+                formats=item_format 
             )
             db_session.add(new_item)
         

--- a/lenny/models/items.py
+++ b/lenny/models/items.py
@@ -8,9 +8,15 @@
     :license: see LICENSE for more details
 """
 
-from sqlalchemy  import Column, String, Boolean, Integer, BigInteger, DateTime
+from sqlalchemy  import Column, String, Boolean, Integer, BigInteger, DateTime, Enum as SQLAlchemyEnum
 from sqlalchemy.sql import func
 from . import Base
+import enum
+
+class FormatEnum(enum.Enum):
+    EPUB = 1
+    PDF = 2
+    EPUB_PDF = 3
 
 class Item(Base):
     __tablename__ = 'items'
@@ -19,6 +25,6 @@ class Item(Base):
     openlibrary_edition = Column(BigInteger, nullable=False)
     encrypted = Column(Boolean, default= False, nullable=False)
     s3_filepath = Column(String, nullable=False)
+    formats = Column(SQLAlchemyEnum(FormatEnum), nullable=False)
     created_at = Column(DateTime(timezone=True), default=func.now())
     updated_at = Column(DateTime(timezone=True), default=func.now(), onupdate=func.now())
-    

--- a/scripts/load_open_books.py
+++ b/scripts/load_open_books.py
@@ -1,4 +1,3 @@
-\
 import requests
 import tempfile
 import re
@@ -7,7 +6,7 @@ import time
 
 OPENLIBRARY_SEARCH_URL = "https://openlibrary.org/search.json?q=id_standard_ebooks:*&fields=key,title,id_standard_ebooks,editions&limit=103"
 STANDARDEBOOKS_BASE_URL = "https://standardebooks.org/ebooks"
-UPLOAD_API_URL = "http://localhost:8080/v1/api/upload"
+UPLOAD_API_URL = "http://localhost:{LENNY_PORT}/v1/api/upload"
 
 def extract_edition_number(ol_key_str):
     if not ol_key_str:

--- a/scripts/load_open_books.py
+++ b/scripts/load_open_books.py
@@ -1,0 +1,118 @@
+\
+import requests
+import tempfile
+import re
+import os
+import time
+
+OPENLIBRARY_SEARCH_URL = "https://openlibrary.org/search.json?q=id_standard_ebooks:*&fields=key,title,id_standard_ebooks,editions&limit=103"
+STANDARDEBOOKS_BASE_URL = "https://standardebooks.org/ebooks"
+UPLOAD_API_URL = "http://localhost:8080/v1/api/upload"
+
+def extract_edition_number(ol_key_str):
+    if not ol_key_str:
+        return None
+    match = re.search(r"/OL(\d+)[MW]$", ol_key_str)
+    if match:
+        return int(match.group(1))
+    return None
+
+def process_book(session, book_data):
+    title = book_data.get('title', 'Unknown Title')
+    standard_ebook_ids = book_data.get("id_standard_ebooks")
+    if not standard_ebook_ids:
+        return False
+    
+    standard_ebook_id = standard_ebook_ids[0] 
+    standard_ebook_id_path_part = standard_ebook_id
+    standard_ebook_id_file_part = standard_ebook_id.replace("/", "_")
+    download_url = f"{STANDARDEBOOKS_BASE_URL}/{standard_ebook_id_path_part}/downloads/{standard_ebook_id_file_part}.epub?source=download"
+    
+    tmp_epub_filepath = None
+
+    try:
+        response = session.get(download_url, stream=True, timeout=60, allow_redirects=True)
+        response.raise_for_status()
+
+        with tempfile.NamedTemporaryFile(suffix=".epub", delete=False) as tmp_epub_file:
+            for chunk in response.iter_content(chunk_size=8192):
+                tmp_epub_file.write(chunk)
+            tmp_epub_filepath = tmp_epub_file.name
+        
+        ol_edition_key_str = None
+        editions_data = book_data.get("editions")
+        if editions_data:
+            edition_docs = editions_data.get("docs")
+            if edition_docs and isinstance(edition_docs, list) and len(edition_docs) > 0:
+                first_edition = edition_docs[0]
+                if isinstance(first_edition, dict):
+                    ol_edition_key_str = first_edition.get("key")
+        
+        if not ol_edition_key_str:
+            ol_edition_key_str = book_data.get("key")
+            if not ol_edition_key_str:
+                if tmp_epub_filepath and os.path.exists(tmp_epub_filepath):
+                    os.remove(tmp_epub_filepath)
+                return False
+
+        openlibrary_edition_num = extract_edition_number(ol_edition_key_str)
+        if openlibrary_edition_num is None:
+            if tmp_epub_filepath and os.path.exists(tmp_epub_filepath):
+                os.remove(tmp_epub_filepath)
+            return False
+
+        data_payload = {
+            'openlibrary_edition': openlibrary_edition_num,
+            'encrypted': False 
+        }
+        
+        with open(tmp_epub_filepath, 'rb') as f_to_upload:
+            files_payload = {
+                'file': (os.path.basename(tmp_epub_filepath), f_to_upload, 'application/epub+zip')
+            }
+            upload_response = session.post(UPLOAD_API_URL, data=data_payload, files=files_payload, timeout=120, verify=False)
+            upload_response.raise_for_status()
+            return True
+
+    except requests.exceptions.RequestException as e:
+        return False
+    except IOError as e:
+        return False
+    finally:
+        if tmp_epub_filepath and os.path.exists(tmp_epub_filepath):
+            try:
+                os.remove(tmp_epub_filepath)
+            except OSError:
+                pass
+        time.sleep(0.1)
+    return False
+
+
+def main():
+    uploaded_books_count = 0
+    print("Starting to load books from Open Library...")
+    with requests.Session() as session:
+        session.headers.update({'User-Agent': 'OpenBooksLoaderScript/1.0'})
+        try:
+            response = session.get(OPENLIBRARY_SEARCH_URL, timeout=30)
+            response.raise_for_status()
+            data = response.json()
+        except requests.exceptions.RequestException:
+            return
+        except ValueError:
+            return
+
+        books = data.get("docs", [])
+        if not books:
+            return
+            
+        for book in books:
+            if isinstance(book, dict):
+                if process_book(session, book):
+                    uploaded_books_count += 1
+        
+        print(f"Total books successfully uploaded: {uploaded_books_count}")
+
+if __name__ == "__main__":
+    requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
+    main()


### PR DESCRIPTION
closes #17 
@mekarpeles, currently, I haven’t added the auto-run configuration to run the script. Instead, I’ve added the manual run command in the README file.

This pull request introduces functionality to support handling different file formats for uploaded items, adds a new script for loading books from Open Library, and updates documentation. The changes primarily focus on enhancing file format validation, database schema updates, and automating book uploads.

### File Format Handling Enhancements:
* [`lenny/core/itemsUpload.py`](diffhunk://#diff-aa49b1f205280dd045d5f2172662c34fd7a86468e46ea66277c50f44523f8a5eR29-R41): Added validation for file formats (`.pdf` and `.epub`) using the newly introduced `FormatEnum`. Unsupported formats now raise an HTTP 400 error.
* [`lenny/models/items.py`](diffhunk://#diff-26cf2f5dcbb9bdaaa19799606e30eb1667fc9dcfa4e17a91fb048fe1099f2758L11-R19): Introduced `FormatEnum` as an enumeration for file formats and added a new `formats` column to the `Item` model to store the file format. [[1]](diffhunk://#diff-26cf2f5dcbb9bdaaa19799606e30eb1667fc9dcfa4e17a91fb048fe1099f2758L11-R19) [[2]](diffhunk://#diff-26cf2f5dcbb9bdaaa19799606e30eb1667fc9dcfa4e17a91fb048fe1099f2758R28-L24)

### Open Library Book Loading Automation:
* [`scripts/load_open_books.py`](diffhunk://#diff-91c31e69fbca52d586fae955a9b9d28a6330ae11910567f091d85e1e06e07109R1-R118): Added a script that fetches book data from Open Library, downloads `.epub` files, and uploads them using the API. Includes error handling and cleanup for temporary files.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R33): Updated setup instructions to include the new `load_open_books.py` script for loading books.
