### PR TITLE
Format support for items

### DIFF
--- a/lenny/models/__init__.py
+++ b/lenny/models/__init__.py
@@ -20,10 +20,16 @@ from . import items
 engine = create_engine(DB_URI, echo=DEBUG, client_encoding='utf8')
 db = scoped_session(sessionmaker(bind=engine, autocommit=False, autoflush=False))
 
-
 def init_db(engine_to_init=engine):
     """Initializes the database and creates tables."""
     Base.metadata.create_all(bind=engine_to_init)
 
+def _auto_init_db():
+    try:
+        init_db(engine)
+    except Exception as e:
+        print(f"[WARNING] Database initialization failed: {e}")
+
+_auto_init_db()
 
 __all__ = ["Base", "db", "engine", "items", "init_db"]

--- a/lenny/models/items.py
+++ b/lenny/models/items.py
@@ -8,9 +8,15 @@
     :license: see LICENSE for more details
 """
 
-from sqlalchemy  import Column, String, Boolean, Integer, BigInteger, DateTime
+from sqlalchemy  import Column, String, Boolean, Integer, BigInteger, DateTime, Enum as SQLAlchemyEnum
 from sqlalchemy.sql import func
 from . import Base
+import enum
+
+class FormatEnum(enum.Enum):
+    EPUB = 1
+    PDF = 2
+    EPUB_PDF = 3
 
 class Item(Base):
     __tablename__ = 'items'
@@ -19,6 +25,6 @@ class Item(Base):
     openlibrary_edition = Column(BigInteger, nullable=False)
     encrypted = Column(Boolean, default= False, nullable=False)
     s3_filepath = Column(String, nullable=False)
+    formats = Column(SQLAlchemyEnum(FormatEnum), nullable=False)
     created_at = Column(DateTime(timezone=True), default=func.now())
     updated_at = Column(DateTime(timezone=True), default=func.now(), onupdate=func.now())
-    


### PR DESCRIPTION
closes #32 

This pull request introduces support for handling file formats in the `upload_items` function and adds database initialization automation. Key changes include the introduction of a new `FormatEnum` to represent file formats, updates to the `Item` model to include a `formats` column, and enhancements to handle unsupported file formats. Additionally, a mechanism for automatic database initialization has been implemented.

### File Format Support:

* **Added `FormatEnum` to represent supported file formats**: Introduced a new `FormatEnum` in `lenny/models/items.py` to define supported formats (`EPUB`, `PDF`, `EPUB_PDF`). 
* **Updated `Item` model**: Added a `formats` column to the `Item` model, using `SQLAlchemyEnum(FormatEnum)` to store the file format for each item. 
* **Enhanced `upload_items` function**: 
  

- [x] - Added logic to determine the file format (`.pdf` or `.epub`) based on the file extension.
- [x]   - Raised an `HTTPException` for unsupported file formats with a clear error message. 
- [x]   - Included the `formats` attribute when creating new `Item` instances. 

### Database Initialization:

* **Automatic database initialization**: Added a private `_auto_init_db` function in `lenny/models/__init__.py` to initialize the database automatically during module import, with error handling and a warning message in case of failure. 