### PR TITLE
Single bucket support

### DIFF
--- a/lenny/core/__init__.py
+++ b/lenny/core/__init__.py
@@ -24,7 +24,7 @@ s3 = session.client(
 )
 
 # Define bucket names
-BUCKET_NAMES = ["bookshelf-public", "bookshelf-encrypted"]
+BUCKET_NAMES = ["bookshelf"]
 
 # Create buckets if they don't exist
 for bucket_name in BUCKET_NAMES:

--- a/lenny/core/itemsUpload.py
+++ b/lenny/core/itemsUpload.py
@@ -19,13 +19,16 @@ from lenny.core import s3
 
 def upload_items(openlibrary_edition: int, encrypted: bool, files: list[UploadFile], db_session: Session = db):
 
-    bucket_name = "bookshelf-encrypted" if encrypted else "bookshelf-public"
-
+    bucket_name = "bookshelf" 
+        
     for file_upload in files:
         if not file_upload.filename:
             continue 
         file_extension = Path(file_upload.filename).suffix.lower()
-        s3_object_name = f"{openlibrary_edition}{file_extension}"
+        if encrypted:
+            s3_object_name = f"{openlibrary_edition}_encrypted{file_extension}"
+        else:
+            s3_object_name = f"{openlibrary_edition}{file_extension}"
         
         try:
             file_upload.file.seek(0)


### PR DESCRIPTION
closes #34 

This pull request simplifies the handling of S3 bucket names and improves the logic for naming uploaded files. The most important changes include consolidating bucket names into a single bucket, updating the upload logic to reflect the new bucket structure, and adding conditional logic for naming encrypted files.

### S3 Bucket Name Simplification:
* [`lenny/core/__init__.py`](diffhunk://#diff-256981c7e12a3c1fede3d52e8207300b8a600bf2399b2ad04e29208b8519b040L27-R27): Consolidated `BUCKET_NAMES` from two separate buckets (`bookshelf-public` and `bookshelf-encrypted`) into a single bucket named `bookshelf`.

### File Upload Logic Updates:
* [`lenny/core/itemsUpload.py`](diffhunk://#diff-aa49b1f205280dd045d5f2172662c34fd7a86468e46ea66277c50f44523f8a5eL22-R29): Updated the `bucket_name` assignment in the `upload_items` function to use the single `bookshelf` bucket regardless of encryption status.
* [`lenny/core/itemsUpload.py`](diffhunk://#diff-aa49b1f205280dd045d5f2172662c34fd7a86468e46ea66277c50f44523f8a5eL41-R43): Added conditional logic to append `_encrypted` to the S3 object name for encrypted files when uploading, ensuring clear differentiation between encrypted and non-encrypted files.