### PR TITLE
fix: Shell-scripts locate bash via env in shebang

### DIFF
--- a/docker/configure.sh
+++ b/docker/configure.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ENV_FILE=".env"
 

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./docker/configure.sh
 


### PR DESCRIPTION
Different systems put bash in different places. Using `/usr/bin/env` works around this and runs the first bash found on the $PATH.