### PR TITLE
itemsUpload.py: Fix undefined name FormatEnum on line 27

### DIFF
--- a/lenny/core/itemsUpload.py
+++ b/lenny/core/itemsUpload.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session
 from botocore.exceptions import ClientError 
 
 from lenny.models import db
-from lenny.models.items import Item  
+from lenny.models.items import FormatEnum, Item  
 from lenny.core import s3 
 
 def upload_items(openlibrary_edition: int, encrypted: bool, files: list[UploadFile], db_session: Session = db):


### PR DESCRIPTION
% `ruff check --output-format=github --select=E9,F63,F7,F82`
```
Error: lenny/core/itemsUpload.py:27:22: F821 Undefined name `FormatEnum`
Error: Process completed with exit code 1.
```
https://docs.astral.sh/ruff