### PR TITLE
Fix env default host

### DIFF
--- a/docker/configure.sh
+++ b/docker/configure.sh
@@ -14,7 +14,7 @@ genpass() {
 }
 
 # Use environment variables if they are set, otherwise provide defaults or generate secure values
-LENNY_HOST="${LENNY_HOST:-127.0.0.1}"
+LENNY_HOST="localhost"
 LENNY_PORT="${LENNY_PORT:-8080}"
 LENNY_WORKERS="${LENNY_WORKERS:-1}"
 LENNY_LOG_LEVEL="${LENNY_LOG_LEVEL:-debug}"


### PR DESCRIPTION
Sometimes if LENNY_HOST is set from `--public` it was setting and the `.env` file was deleted, this host would be defaulted by configure.sh. This defaults LENNY_HOST to be localhost and overrides values as needed via LENNY_PROXY