### PR TITLE
Update public URL output in create_tunnel function and add prompt for…

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -108,7 +108,7 @@ function create_tunnel() {
         # Try to extract any https://*.trycloudflare.com or https://*.cfargotunnel.com URL
         URL=$(grep -Eo 'https://[a-zA-Z0-9.-]+\.(trycloudflare|cfargotunnel)\.com' cloudflared.log | head -n1)
         if [[ -n "$URL" ]]; then
-            echo "[+] Your public URL is: $URL"
+            echo "[+] Your public URL is: $URL/v1/api/"
 	    read -p "[+] Setting as LENNY_PROXY. Press Enter to continue..."
 	    export LENNY_PROXY=$URL
             return 0
@@ -153,4 +153,6 @@ fi
 
 if [[ "$LOG" == "true" ]]; then
     docker compose logs -f
+elif [[ "$PUBLIC" == "true" ]]; then
+    read -p "[+] Press Enter to close tunnel..."
 fi


### PR DESCRIPTION
This pull request includes updates to the `run.sh` script to enhance functionality for handling public URLs and tunnel management. The changes primarily focus on modifying the output format of the public URL and adding a user prompt for closing the tunnel when the `PUBLIC` flag is set.

Enhancements to public URL handling:

* [`run.sh`](diffhunk://#diff-d31ce0453051853c17ba2a5225b3d1bfab548e095bab0967d6acfd1b3ce1b35dL111-R111): Updated the public URL output in the `create_tunnel` function to include the `/v1/api/` suffix for better API integration.

Tunnel management improvements:

* [`run.sh`](diffhunk://#diff-d31ce0453051853c17ba2a5225b3d1bfab548e095bab0967d6acfd1b3ce1b35dR156-R157): Added a conditional block to prompt the user to press Enter to close the tunnel when the `PUBLIC` flag is set.