### PR TITLE
Update Readium image version to 0.4.0

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -74,7 +74,7 @@ services:
       - lenny_network
 
   readium:
-    image: ghcr.io/readium/readium:0.3.0
+    image: ghcr.io/readium/readium:0.4.0
     container_name: lenny_readium
     ports:
       - "${READIUM_PORT:-15080}"


### PR DESCRIPTION
This pull request updates the version of the Readium service in the `compose.yaml` file to ensure compatibility with the latest features and fixes.

* [`compose.yaml`](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cL77-R77): Updated the Readium service image from version `0.3.0` to `0.4.0` to incorporate improvements and bug fixes from the newer release.

Check for more information [Readium CLI 0.4.0](https://github.com/readium/cli/releases/tag/v0.4.0)