### PR TITLE
auth-flow bug fix for open access books 

### DIFF
--- a/lenny/core/auth.py
+++ b/lenny/core/auth.py
@@ -46,6 +46,8 @@ def get_authenticated_email(session) -> Optional[str]:
 def verify_session_cookie(session, client_ip: str = None) -> Optional[str]:
     """Retrieves and verifies email from signed cookie, optionally checking IP."""
     try:
+        if not session:
+            raise ValueError("Session cookie missing. Please authenticate.")
         data = SERIALIZER.loads(session, max_age=COOKIE_TTL)
         if isinstance(data, dict):
             # New format with IP verification

--- a/lenny/core/models.py
+++ b/lenny/core/models.py
@@ -10,7 +10,6 @@
 
 from sqlalchemy  import Column, String, Boolean, BigInteger, Integer, DateTime, Enum as SQLAlchemyEnum
 from sqlalchemy.sql import func
-from lenny.core.api import LennyAPI
 from lenny.core.db import session as db, Base
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import relationship
@@ -76,6 +75,8 @@ class Item(Base):
         """
         if not email:
             raise EmailNotFoundError("Email is required to borrow encrypted items.")
+        
+        from lenny.core.api import LennyAPI
         
         email_hash = LennyAPI.hash_email(email)
         active_loan = db.query(Loan).filter(

--- a/lenny/routes/api.py
+++ b/lenny/routes/api.py
@@ -19,6 +19,7 @@ from fastapi import (
     HTTPException,
     status,
     Body,
+    Cookie
 )
 from fastapi.responses import (
     HTMLResponse,
@@ -38,6 +39,7 @@ from lenny.core.exceptions import (
     UploaderNotAllowedError,
 )
 from lenny.core.readium import ReadiumAPI
+from lenny.core.models import Item
 from urllib.parse import quote
 
 COOKIES_MAX_AGE = 604800  # 1 week
@@ -62,9 +64,13 @@ async def get_opds(request: Request, offset: Optional[int]=None, limit: Optional
 
 # Redirect to the Thorium Web Reader
 @router.get("/items/{book_id}/read")
-async def redirect_reader(request: Request,book_id: str, format: str = "epub"):
-    session = request.cookies.get("session")
-    email = auth.verify_session_cookie(session, request.client.host)
+async def redirect_reader(request: Request,book_id: str, format: str = "epub", session: Optional[str] = Cookie(None)):
+    email = None
+    if item := Item.exists(book_id):
+        if item.is_login_required:
+            email = auth.verify_session_cookie(session, request.client.host)
+            if not email:
+                raise HTTPException(status_code=401, detail="Authentication required to access this item.")
     if not LennyAPI.auth_check(book_id, email=email, session=session):
         return JSONResponse(
             status_code=401,
@@ -81,9 +87,14 @@ async def redirect_reader(request: Request,book_id: str, format: str = "epub"):
     return RedirectResponse(url=reader_url, status_code=307)
 
 @router.get("/items/{book_id}/readium/manifest.json")
-async def get_manifest(request: Request, book_id: str, format: str=".epub"):
-    session = request.cookies.get("session")
-    email = auth.verify_session_cookie(session, request.client.host)
+async def get_manifest(request: Request, book_id: str, format: str=".epub" , session: Optional[str] = Cookie(None)):
+    email = None
+    if item := Item.exists(book_id):
+        if item.is_login_required:
+            session = request.cookies.get("session")
+            email = auth.verify_session_cookie(session, request.client.host)
+            if not email:
+                raise HTTPException(status_code=401, detail="Authentication required to access this item.")
     if not LennyAPI.auth_check(book_id, email=email, session=session):
         raise HTTPException(status_code=400, detail="Unauthorized request")
     try:
@@ -93,9 +104,14 @@ async def get_manifest(request: Request, book_id: str, format: str=".epub"):
 
 # Proxy all other readium requests
 @router.get("/items/{book_id}/readium/{readium_path:path}")
-async def proxy_readium(request: Request, book_id: str, readium_path: str, format: str=".epub"):
-    session = request.cookies.get("session")
-    email = auth.verify_session_cookie(session, request.client.host)
+async def proxy_readium(request: Request, book_id: str, readium_path: str, format: str=".epub", session: Optional[str] = Cookie(None)):
+    email = None
+    if item := Item.exists(book_id):
+            if item.is_login_required:
+                session = request.cookies.get("session")
+                email = auth.verify_session_cookie(session, request.client.host)
+                if not email:
+                    raise HTTPException(status_code=401, detail="Authentication required to access this item.")
     if not LennyAPI.auth_check(book_id, email=email, session=session):
         raise HTTPException(status_code=400, detail="Unauthorized request")
     readium_url = ReadiumAPI.make_url(book_id, format, readium_path)
@@ -165,15 +181,20 @@ async def authenticate(request: Request, response: Response, email: str = Form(.
     return {"success": False}
 
 @router.post('/items/{book_id}/borrow', status_code=status.HTTP_200_OK)
-async def borrow_item(request: Request,  book_id: int, otp: Optional[str] = Body(None, embed=True)):
+async def borrow_item(request: Request,  book_id: int, session: str = Cookie(None)):
     """
     Handles the borrowing of a book for a patron.
     Requires the patron's email and checks if they are logged in.
     If not logged in, checks the OTP and sets cookies if valid.
     """
-    session = request.cookies.get("session")
-    email = auth.verify_session_cookie(session, request.client.host)
-    success = LennyAPI.auth_check(book_id, session=session)
+    email = None
+    if item := Item.exists(book_id):
+        if item.is_login_required:
+            session = request.cookies.get("session")
+            email = auth.verify_session_cookie(session, request.client.host)
+            if not email:
+                return RedirectResponse(url="/authenticate", status_code=303)
+    success = LennyAPI.auth_check(book_id, email=email , session=session)
     if not success:
         return RedirectResponse(url="/authenticate", status_code=303)
     try:


### PR DESCRIPTION
This pull request improves authentication handling and code organization in several key API endpoints, focusing on more robust session validation and better error handling for protected resources. It also introduces minor code organization improvements. The most important changes are:

**Authentication and Session Handling Improvements:**

* All endpoints that require user authentication now consistently extract the `session` cookie using FastAPI's `Cookie` dependency, and verify the session before granting access to protected resources. If authentication fails, a clear error or redirect is returned. [[1]](diffhunk://#diff-c850c1516b1be232d38a31c91cf176bded69d6c27f1556977097e60961196cc1L65-R73) [[2]](diffhunk://#diff-c850c1516b1be232d38a31c91cf176bded69d6c27f1556977097e60961196cc1L84-R97) [[3]](diffhunk://#diff-c850c1516b1be232d38a31c91cf176bded69d6c27f1556977097e60961196cc1L96-R114) [[4]](diffhunk://#diff-c850c1516b1be232d38a31c91cf176bded69d6c27f1556977097e60961196cc1L168-R197)
* The `verify_session_cookie` function in `lenny/core/auth.py` now explicitly checks for a missing session cookie and raises a user-friendly error if it is absent.

**API Endpoint Updates:**

* The `/items/{book_id}/read`, `/items/{book_id}/readium/manifest.json`, and `/items/{book_id}/readium/{readium_path:path}` endpoints now require authentication for items marked as login-required, and will return a 401 error if the user is not authenticated. [[1]](diffhunk://#diff-c850c1516b1be232d38a31c91cf176bded69d6c27f1556977097e60961196cc1L65-R73) [[2]](diffhunk://#diff-c850c1516b1be232d38a31c91cf176bded69d6c27f1556977097e60961196cc1L84-R97) [[3]](diffhunk://#diff-c850c1516b1be232d38a31c91cf176bded69d6c27f1556977097e60961196cc1L96-R114)
* The `/items/{book_id}/borrow` endpoint now requires a valid session cookie for login-required items, and redirects unauthenticated users to the authentication page.

**Code Organization and Dependency Management:**

* The import of `LennyAPI` in `lenny/core/models.py` was moved inside the `borrow` method to avoid unnecessary imports and potential circular dependencies. [[1]](diffhunk://#diff-3f5b6b73cd03af61fd33b2ef0cdd2a0f455ddbfd21ba7f479148a570e332d270L13) [[2]](diffhunk://#diff-3f5b6b73cd03af61fd33b2ef0cdd2a0f455ddbfd21ba7f479148a570e332d270R79-R80)
* Added missing imports for `Cookie` and `Item` in `lenny/routes/api.py` to support the new authentication logic. [[1]](diffhunk://#diff-c850c1516b1be232d38a31c91cf176bded69d6c27f1556977097e60961196cc1R22) [[2]](diffhunk://#diff-c850c1516b1be232d38a31c91cf176bded69d6c27f1556977097e60961196cc1R42)