### PR TITLE
Add URL encoding for manifest links in LennyAPI and ReadiumAPI

### DIFF
--- a/lenny/core/api.py
+++ b/lenny/core/api.py
@@ -29,6 +29,7 @@ from lenny.configs import (
     SCHEME, HOST, PORT, PROXY,
     READER_PORT
 )
+from urllib.parse import quote
 
 class LennyAPI:
 
@@ -44,6 +45,11 @@ class LennyAPI:
     @classmethod
     def make_manifest_url(cls, book_id):
         return cls.make_url(f"/v1/api/items/{book_id}/readium/manifest.json")
+    
+    @classmethod
+    def encoded_manifest_url(cls, book_id):
+        manifest_uri = cls.make_manifest_url(book_id)
+        return quote(manifest_uri, safe='')
 
     @classmethod
     def make_url(cls, path):

--- a/lenny/core/readium.py
+++ b/lenny/core/readium.py
@@ -18,6 +18,7 @@ from lenny.core.api import LennyAPI
 from lenny.core.utils import encode_book_path
 from lenny.core.exceptions import ItemNotFoundError
 from lenny.configs import READIUM_BASE_URL
+from urllib.parse import quote
 
 class ReadiumAPI:
 
@@ -43,4 +44,6 @@ class ReadiumAPI:
                 manifest['links'][i]['href'] = LennyAPI.make_url(
                     f"/v1/api/items/{book_id}/readium/manifest.json"
                 )
+        encoded_manifest = quote(manifest['links'][i]['href'], safe='')
+        manifest['links'][i]['href'] = encoded_manifest
         return manifest


### PR DESCRIPTION
This pull request introduces improvements for URL encoding in the manifest handling logic. The main changes ensure that manifest URLs are properly encoded before use, which helps prevent issues with special characters in URLs.

**URL Encoding Enhancements:**

* Added a new method `encoded_manifest_url` to the `LennyAPI` class that returns a URL-encoded manifest URL for a given `book_id`.
* Updated the `patch_manifest` method in `ReadiumAPI` to URL-encode the manifest link after constructing it, ensuring the link is safe for use in web contexts.

**Imports for URL Encoding:**

* Imported the `quote` function from `urllib.parse` in both `lenny/core/api.py` and `lenny/core/readium.py` to support URL encoding operations. [[1]](diffhunk://#diff-daea9adfc6a724cd61b2c765b7ed1e9d21712d5bd3fce17212f4e66af731abcfR32) [[2]](diffhunk://#diff-2ec58ee78af644642f7b103286b73fb4bdeac36cd11f55b870ee537eb4cd501aR21)