### PR TITLE
Update Dockerfile to clone specific version of thorium-web

### DIFF
--- a/docker/reader/Dockerfile
+++ b/docker/reader/Dockerfile
@@ -14,7 +14,10 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y git
 
-RUN git clone https://github.com/edrlab/thorium-web.git
+RUN git clone https://github.com/edrlab/thorium-web.git && \
+    cd thorium-web && \
+    git checkout v1.0.4
+    
 RUN corepack enable
 
 WORKDIR /app/thorium-web


### PR DESCRIPTION
This pull request updates the `docker/reader/Dockerfile` to ensure that the `thorium-web` repository is checked out at a specific version (`v1.0.4`) after cloning. This change helps guarantee build consistency by always using the same code version.

Dependency management:

* Modified the `git clone` command to check out the `v1.0.4` tag of the `thorium-web` repository, ensuring a consistent and reproducible build environment.

Issue: 
- Reader app is breaking while redirect when Thorium web reader is having a new version release.

Solution:
- Locking thorium web reader app to release [version v1.0.4 ](https://github.com/edrlab/thorium-web/releases/tag/v1.0.4) 

 