### PR TITLE
Fix service name references in lenny.sh for consistency

### DIFF
--- a/docker/utils/lenny.sh
+++ b/docker/utils/lenny.sh
@@ -21,7 +21,7 @@ if [[ -n "$URL" ]]; then
 
     if docker ps -q -f name=lenny_api >/dev/null; then
         echo "[+] Restarting lenny_api to pick up updated LENNY_PROXY"
-        docker compose -p lenny up -d --no-deps lenny_api
+        docker compose -p lenny up -d --no-deps api
     fi
 fi
 
@@ -34,7 +34,7 @@ fi
 if [[ "$1" == "--start" || "$1" == "--rebuild" ]]; then
     docker compose -p lenny up -d
 elif [[ "$1" == "--restart" ]]; then
-    docker compose -p lenny restart lenny_api
+    docker compose -p lenny restart api
 elif [[ "$1" == "--stop" ]]; then
     docker compose -p lenny stop
 else


### PR DESCRIPTION
This pull request updates the service name used in Docker Compose commands within the `docker/utils/lenny.sh` script. The changes ensure that the script refers to the correct service name, updating from `lenny_api` to `api` for consistency with the Docker Compose configuration.

###  Issue 

docker compose restarts by service name, not container name.
<img width="499" height="62" alt="Screenshot 2025-10-22 at 11 44 21 AM" src="https://github.com/user-attachments/assets/778367f8-1115-4aa6-8090-a47e44b9a314" />


**Docker Compose service name updates:**

* Updated the `docker compose up` and `docker compose restart` commands to use the `api` service name instead of `lenny_api` in the `lenny.sh` script. [[1]](diffhunk://#diff-47a21021b66944249e123fd4728da99e94743e08067bcfb100075ccf8e98af01L24-R24) [[2]](diffhunk://#diff-47a21021b66944249e123fd4728da99e94743e08067bcfb100075ccf8e98af01L37-R37)

Now is able to pick up the latest `LENNY_PROXY` when we use `make restart` making `lenny_api` to restart the `api` service