### PR TITLE
Refactor OPDS feed navigation to use Navigation and Link models for improved structure

### DIFF
--- a/lenny/core/api.py
+++ b/lenny/core/api.py
@@ -5,6 +5,7 @@ from botocore.exceptions import ClientError
 import socket
 from pyopds2_lenny import LennyDataProvider
 from pyopds2 import Catalog, Metadata
+from pyopds2.models import Link, Navigation
 from lenny.core import db, s3, auth
 from lenny.core.utils import hash_email
 from lenny.core.models import Item, FormatEnum, Loan
@@ -149,13 +150,13 @@ class LennyAPI:
         def _href(path: str) -> str:
             return cls.make_url(path)
         return [
-            {"href": _href("/v1/api/opds/"), "title": "Home", "type": "text/html"},
-            {
-                "href": _href(f"/v1/api/opds?offset=0&limit={limit}"),
-                "title": "Catalog",
-                "type": "application/opds+json",
-                "rel": "collection",
-            },
+            Navigation(href=_href("/"), title="Home", type="text/html"),
+            Navigation(
+                href=_href(f"/v1/api/opds?offset=0&limit={limit}"),
+                title="Catalog",
+                type="application/opds+json",
+                rel="collection",
+            ),
         ]
 
     @classmethod
@@ -164,8 +165,8 @@ class LennyAPI:
         def _href(path: str) -> str:
             return cls.make_url(path)
         return [
-            {"rel": "self", "href": _href(f"/v1/api/opds?offset={offset}&limit={limit}")},
-            {"rel": "next", "href": _href(f"/v1/api/opds?offset={offset + limit}&limit={limit}")},
+            Link(rel="self", href=_href(f"/v1/api/opds?offset={offset}&limit={limit}")),
+            Link(rel="next", href=_href(f"/v1/api/opds?offset={offset + limit}&limit={limit}")),
         ]
 
     @classmethod


### PR DESCRIPTION
This pull request refactors parts of the OPDS API implementation to use the `Navigation` and `Link` model classes from the `pyopds2` library instead of plain dictionaries. This change improves type safety and code clarity.

**Refactoring to use model classes:**

* Updated the `_navigation` method in `lenny/core/api.py` to return `Navigation` objects instead of dictionaries for navigation links.
* Updated the `_catalog_links` method in `lenny/core/api.py` to return `Link` objects instead of dictionaries for catalog pagination links.

**Dependency import updates:**

* Added imports for `Link` and `Navigation` from `pyopds2.models` in `lenny/core/api.py`.