### PR TITLE
Refactor URL construction in LennyAPI and update HTTP_TIMEOUT in OpenLibrary

### DIFF
--- a/lenny/core/api.py
+++ b/lenny/core/api.py
@@ -28,6 +28,16 @@ from lenny.configs import (
 )
 from urllib.parse import quote
 
+def _make_url(path):
+    if PROXY:
+        return f"{PROXY}{path}"
+    url = f"{SCHEME}://{HOST}"
+    if PORT and PORT not in {80, 443}:
+        url += f":{PORT}"
+    return f"{url}{path}"
+
+LennyDataProvider.BASE_URL = _make_url("/v1/api/")
+
 class LennyAPI:
 
     DEFAULT_LIMIT = 50
@@ -52,12 +62,8 @@ class LennyAPI:
     def make_url(cls, path):
         """Constructs a public Lenny URL that points to the public HOST and PORT
         """
-        if PROXY:
-            return f"{PROXY}{path}"
-        url = f"{SCHEME}://{HOST}"
-        if PORT and PORT not in {80, 443}:
-            url += f":{PORT}"
-        return f"{url}{path}"
+        
+        return _make_url(path)
 
     @classmethod
     def auth_check(cls, item, session: str=None, request: Request=None):

--- a/lenny/core/openlibrary.py
+++ b/lenny/core/openlibrary.py
@@ -11,7 +11,7 @@ class OpenLibrary:
     
     SEARCH_URL = "https://openlibrary.org/search.json"
     HTTP_HEADERS = LENNY_HTTP_HEADERS
-    HTTP_TIMEOUT = 5
+    HTTP_TIMEOUT = 10
     DEFAULT_FIELDS = [
         'key', 'title', 'author_key', 'author_name', 'editions', 'editions.*',
     ]


### PR DESCRIPTION
This pull request introduces improvements to URL construction and configuration in the `lenny/core/api.py` and `lenny/core/openlibrary.py` files. The most notable change is the centralization of URL creation logic, which helps ensure consistency and maintainability. Additionally, the HTTP timeout for OpenLibrary requests has been increased to improve reliability.

**URL Construction Improvements:**

* Added a new `_make_url` helper function to centralize and standardize URL construction logic, replacing duplicate code and reducing errors. (`lenny/core/api.py`)
* Updated the `make_url` and `encoded_manifest_url` methods to use the new `_make_url` function for building URLs. (`lenny/core/api.py`)
* Set the `LennyDataProvider.BASE_URL` using the new `_make_url` helper, ensuring it uses the correct scheme, host, port, and proxy if configured. (`lenny/core/api.py`)

**Configuration Updates:**

* Increased the HTTP timeout for OpenLibrary requests from 5 to 10 seconds to reduce the likelihood of timeouts during slow network conditions. (`lenny/core/openlibrary.py`)

Now we are able to add prefixed domain URL before acquisition links in OPDS feed. 