### PR TITLE
Fix FastAPI Swagger specs not loading from /docs due to Nginx config

### DIFF
--- a/docker/nginx/conf.d/lenny.conf
+++ b/docker/nginx/conf.d/lenny.conf
@@ -14,7 +14,18 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    location /v1/api/docs {
+        proxy_pass http://lenny_api:1337/docs;
+    }
 
+    location /v1/api/openapi.json {
+        proxy_pass http://lenny_api:1337/openapi.json;
+    }
+
+    location = /openapi.json {
+        proxy_pass http://lenny_api:1337/openapi.json;
+    }
+    
     location /read {
 	proxy_pass http://lenny_reader:3000/read;
 	proxy_set_header Host $http_host;


### PR DESCRIPTION
closes #111 

**Problem**:
    The Fastapi swagger specs are not being fetched from the /docs endpoint.

**Solution**:
    /docs → FastAPI docs UI
    /openapi.json → Swagger spec file FastAPI generates.

    FastAPI /docs is at /docs, not under /v1/api. Nginx has no rule for /docs. So request hits Nginx → nowhere to send → 404.
    
Screenshot:
<img width="1440" height="900" alt="Screenshot 2025-11-13 at 16 36 49" src="https://github.com/user-attachments/assets/d68c98c5-8f27-4702-b0c9-6a724b8ada8e" />

**Learning Curve:**
When add only /docs endpoint encountered error. /docs was unreachable because it requires /openapi.json, and Nginx wasn’t exposing that endpoint. Once you added the Nginx routes for /openapi.json, /docs started working.
<img width="1440" height="900" alt="Screenshot 2025-11-13 at 16 45 46" src="https://github.com/user-attachments/assets/cc6bf253-d2e9-4171-87e0-3158c83285a9" />

