### PR TITLE
Add functionality to upload books with OpenLibrary Edition ID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,3 +64,16 @@ rebuild:
 stop:
 	@bash docker/utils/lenny.sh --stop
 	@$(MAKE) untunnel
+
+# Add a book with OpenLibrary Edition ID
+# Usage: make addbook olid=OL123456M filepath=/path/to/book.epub [encrypted=true]
+# Note: On macOS, if file is in ~/Downloads, you may need to grant Terminal "Full Disk Access"
+#       or copy the file to the project directory first
+.PHONY: addbook
+addbook:
+	@if [ -z "$(olid)" ] || [ -z "$(filepath)" ]; then \
+		echo "Error: Missing required arguments."; \
+		echo "Usage: make addbook olid=OL123456M filepath=/path/to/book.epub [encrypted=true]"; \
+		exit 1; \
+	fi
+	@bash docker/utils/addbook.sh --olid $(olid) --filepath $(filepath) $(if $(filter true,$(encrypted)),--encrypted,)

--- a/README.md
+++ b/README.md
@@ -134,6 +134,53 @@ docker exec -it lenny_api python scripts/load_open_books.py
 
 ---
 
+## Adding Books
+
+To add a book to Lenny, you must provide an OpenLibrary Edition ID (OLID). Books without an OLID cannot be uploaded.
+
+### Adding Books Metadata
+
+Sign in to your Openlibrary.org account.
+
+```link
+https://openlibrary.org/books/add
+```
+
+navigate to the above link and add all the details.
+
+### Usage
+
+```sh
+make addbook olid=OL123456M filepath=/path/to/book.epub [encrypted=true]
+```
+
+### Examples
+
+```sh
+# Add an unencrypted book
+make addbook olid=OL60638966M filepath=./books/mybook.epub
+
+# Add an encrypted book
+make addbook olid=OL60638966M filepath=./books/mybook.epub encrypted=true
+
+# Using numeric OLID format (without OL prefix and M suffix)
+make addbook olid=60638966 filepath=./books/mybook.epub
+```
+
+### Important Notes
+
+- **File Location**: The EPUB file must be within the project directory (e.g., in `./books/` or project root)
+- **OLID Formats**: Accepts both `OL123456M` and `123456` formats
+- **Duplicates**: If a book with the same OLID already exists, the upload will fail with a conflict.
+
+### Troubleshooting
+
+If you get a "File not found" or permission error, make sure:
+1. The file is copied into your lenny project directory.
+2. You're using a relative path from the project root (e.g., `./books/mybook.epub`)
+
+---
+
 ## Testing Readium Server
 
 ```sh

--- a/docker/utils/addbook.sh
+++ b/docker/utils/addbook.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Helper script to add a book to Lenny via Docker
+
+set -e
+
+source "$(dirname "$0")/docker_helpers.sh"
+
+OLID=""
+FILEPATH=""
+ENCRYPTED="false"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --olid)
+            OLID="$2"
+            shift 2
+            ;;
+        --filepath)
+            FILEPATH="$2"
+            shift 2
+            ;;
+        --encrypted)
+            ENCRYPTED="true"
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$OLID" ] || [ -z "$FILEPATH" ]; then
+    echo "Error: Missing required arguments."
+    echo "Usage: $0 --olid <OLID> --filepath <PATH> [--encrypted]"
+    exit 1
+fi
+
+FILEPATH=$(eval echo "$FILEPATH")
+FILEPATH=$(cd "$(dirname "$FILEPATH")" 2>/dev/null && pwd)/$(basename "$FILEPATH") || FILEPATH="$FILEPATH"
+
+if [ ! -f "$FILEPATH" ]; then
+    echo "Error: File not found: $FILEPATH"
+    exit 1
+fi
+
+if [ ! -r "$FILEPATH" ]; then
+    echo "Error: Cannot read file: $FILEPATH"
+    echo ""
+    echo "If the file is in ~/Downloads, macOS may be blocking access."
+    echo "Please either:"
+    echo "  1. Move/copy the file to the lenny project directory, or"
+    echo "  2. Grant Terminal 'Full Disk Access' in System Settings > Privacy & Security"
+    exit 1
+fi
+
+# Ensure container is running
+if ! wait_for_docker_container "lenny_api" 15 2; then
+    echo "Error: lenny_api container is not running"
+    exit 1
+fi
+
+FILENAME=$(basename "$FILEPATH")
+CONTAINER_PATH="/tmp/${FILENAME}"
+
+echo "[+] Copying file to container..."
+if ! docker cp "$FILEPATH" "lenny_api:${CONTAINER_PATH}" 2>/dev/null; then
+    echo "[+] Direct copy failed, trying alternative method..."
+    cat "$FILEPATH" | docker exec -i lenny_api sh -c "cat > ${CONTAINER_PATH}"
+fi
+
+echo "[+] Uploading book with OLID: $OLID..."
+
+CMD="python scripts/addbook.py --olid $OLID --filepath $CONTAINER_PATH"
+if [ "$ENCRYPTED" = "true" ]; then
+    CMD="$CMD --encrypted"
+fi
+
+if docker exec -i lenny_api $CMD; then
+    echo "[✓] Book uploaded successfully!"
+    EXIT_CODE=0
+else
+    echo "[✗] Upload failed"
+    EXIT_CODE=1
+fi
+
+echo "[+] Cleaning up temporary file..."
+docker exec -i lenny_api rm -f "$CONTAINER_PATH"
+
+exit $EXIT_CODE

--- a/scripts/addbook.py
+++ b/scripts/addbook.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+Script to upload a book to Lenny with an OpenLibrary Edition ID.
+"""
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from lenny.core.client import LennyClient
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Upload a book to Lenny with an OpenLibrary Edition ID"
+    )
+    parser.add_argument(
+        "--olid",
+        type=str,
+        required=True,
+        help="OpenLibrary Edition ID (e.g., OL123456M or just 123456)"
+    )
+    parser.add_argument(
+        "--filepath",
+        type=str,
+        required=True,
+        help="Path to the EPUB file to upload"
+    )
+    parser.add_argument(
+        "--encrypted",
+        action="store_true",
+        default=False,
+        help="Flag to indicate if the book is encrypted"
+    )
+    
+    args = parser.parse_args()
+    
+    filepath = Path(args.filepath)
+    if not filepath.exists():
+        print(f"Error: File not found: {args.filepath}")
+        sys.exit(1)
+    
+    if not filepath.suffix.lower() == '.epub':
+        print(f"Warning: File does not have .epub extension: {args.filepath}")
+    
+    olid = args.olid
+    if olid.startswith('OL') and olid.endswith('M'):
+        olid = olid[2:-1]  
+    
+    try:
+        olid_int = int(olid)
+    except ValueError:
+        print(f"Error: Invalid OLID format: {args.olid}")
+        print("Expected format: OL123456M or 123456")
+        sys.exit(1)
+    
+    print(f"Uploading book with OLID: {olid_int}")
+    print(f"File: {filepath}")
+    print(f"Encrypted: {args.encrypted}")
+    
+    try:
+        with open(filepath, 'rb') as epub:
+            success = LennyClient.upload(
+                olid=olid_int,
+                file_content=epub,
+                encrypted=args.encrypted
+            )
+        
+        if success:
+            print("✓ Book uploaded successfully!")
+            sys.exit(0)
+        else:
+            print("✗ Book upload failed. Check logs for details.")
+            sys.exit(1)
+    except Exception as e:
+        error_msg = str(e)
+        if "409" in error_msg or "Conflict" in error_msg:
+            print(f"✗ Book with OLID {olid_int} already exists in the database.")
+            print("  If you want to replace it, you'll need to delete it first.")
+        else:
+            print(f"✗ Upload failed: {error_msg}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION

This pull request adds a new workflow for uploading books to Lenny using an OpenLibrary Edition ID (OLID). It introduces a new `addbook` Makefile target, a helper shell script, and a Python script to handle book uploads, along with comprehensive documentation in the `README.md`. The changes simplify and standardize the process for adding both encrypted and unencrypted EPUB files to the Lenny system.

**New book upload workflow:**

* Added a new `.PHONY` `addbook` target to the `Makefile` for uploading books via `make addbook olid=<OLID> filepath=<PATH> [encrypted=true]`, with argument validation and usage instructions.
* Created a helper script `docker/utils/addbook.sh` to automate copying EPUB files into the Docker container and invoking the Python upload script, with error handling for file location and permissions.
* Added `scripts/addbook.py` to handle the actual upload logic, including OLID format normalization, file validation, and error reporting for duplicates and upload failures.

**Documentation and usage instructions:**

* Updated `README.md` with a dedicated section for adding books, including step-by-step instructions, usage examples, OLID format notes, troubleshooting tips, and important caveats about file locations and duplicates.