### PR TITLE
Simplify OPDS flow, single opds view

### DIFF
--- a/lenny/routes/api.py
+++ b/lenny/routes/api.py
@@ -8,6 +8,7 @@
     :license: see LICENSE for more details
 """
 
+import json
 import requests
 from functools import wraps
 from typing import Optional, Generator, List
@@ -91,7 +92,22 @@ async def get_items(fields: Optional[str]=None, offset: Optional[int]=None, limi
 
 @router.get("/opds")
 async def get_opds(request: Request, offset: Optional[int]=None, limit: Optional[int]=None):
-    return LennyAPI.opds_feed(offset=offset, limit=limit)
+    return Response(
+        content=json.dumps(
+            LennyAPI.opds_feed(offset=offset, limit=limit)
+        ),
+        media_type="application/opds+json"
+    )
+
+
+@router.get("/opds/{book_id}")
+async def get_opds(request: Request, book_id:int):
+    return Response(
+        content=json.dumps(
+            LennyAPI.opds_feed(olid=book_id)
+        ),
+        media_type="application/opds+json"
+    )
 
 # Redirect to the Thorium Web Reader
 @router.get("/items/{book_id}/read")


### PR DESCRIPTION
This pull request updates the OPDS feed functionality to support fetching feeds for individual items as well as the entire catalog, and refactors the way OPDS feeds are constructed and returned. The changes simplify the API and make it more flexible for both single-item and multi-item OPDS requests.

Key changes include:

### OPDS Feed API Enhancements

* The `LennyAPI.opds_feed` and `LennyAPI.get_enriched_items` methods now accept an optional `olid` parameter, allowing the API to return either a single item's OPDS feed or the full catalog, depending on the presence of this parameter. [[1]](diffhunk://#diff-daea9adfc6a724cd61b2c765b7ed1e9d21712d5bd3fce17212f4e66af731abcfL113-R124) [[2]](diffhunk://#diff-daea9adfc6a724cd61b2c765b7ed1e9d21712d5bd3fce17212f4e66af731abcfL135-R133)
* The `/opds/{book_id}` endpoint was added to serve an OPDS feed for a specific item, returning the result as `application/opds+json`.
* The `/opds` endpoint now explicitly returns the OPDS catalog as JSON with the correct media type.

### Refactoring and Simplification

* The `_build_feed` helper method was removed from `LennyAPI`, consolidating OPDS feed construction logic directly within `opds_feed`, and always using the OPDS2 models for consistency. [[1]](diffhunk://#diff-daea9adfc6a724cd61b2c765b7ed1e9d21712d5bd3fce17212f4e66af731abcfL203-L234) [[2]](diffhunk://#diff-daea9adfc6a724cd61b2c765b7ed1e9d21712d5bd3fce17212f4e66af731abcfL146-R152)
* Minor import cleanup was performed in `lenny/routes/api.py` for better clarity.

### Next steps

@ronibhakta1, the next step is to tweak the https://github.com/ArchiveLabs/pyopds2_lenny search feed https://github.com/ArchiveLabs/pyopds2_lenny/blob/main/pyopds2_lenny/__init__.py#L144 so that it uses the latest pattern described by https://github.com/ArchiveLabs/pyopds2_openlibrary/blob/main/pyopds2_openlibrary/__init__.py#L249-L257

This cleanup will allow two things:
1. Simplifies the `.search` method to return one value
2. Allow us to call `Catalog.create` in a way that generates all the pagination for us (eliminating need for cls._catalog_links)