### PR TITLE
Fix authcheck: Require authorization check for borrowing items

### DIFF
--- a/lenny/core/api.py
+++ b/lenny/core/api.py
@@ -83,6 +83,12 @@ class LennyAPI:
                     "message": "Not authenticated; POST to url to get a one-time-password"
                 }
             success['email'] = email
+            if not (loan := item.borrow(email)):
+                return {
+                    "error": "unauthorized",
+                    "url": f"/v1/api/items/{item.openlibrary_edition}/borrow",
+                    "message": "Book must be borrowed before being read"
+                }
         return success
     
     @classmethod


### PR DESCRIPTION
This pull request fixes/patches an oversight in the `auth_check` method in `lenny/core/api.py` to ensure that a book is borrowed before it can be read. If the user has not borrowed the book, the API now returns an error message and a URL to borrow the book.

Authorization and access control improvements:

* Added a check in `auth_check` to verify that the user has borrowed the item before allowing access; returns an error and a borrow URL if not borrowed.