### PR TITLE
Add CORS headers to nginx configuration for BookServer and Cloudflare requests

### DIFF
--- a/docker/nginx/conf.d/lenny.conf
+++ b/docker/nginx/conf.d/lenny.conf
@@ -6,6 +6,12 @@ server {
     error_log /var/log/nginx/error.log debug;
     access_log /var/log/nginx/access.log;
 
+    # CORS headers to allow BookServer / Cloudflare requests
+    add_header Access-Control-Allow-Origin * always;
+    add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS" always;
+    add_header Access-Control-Allow-Headers "Content-Type, Authorization" always;
+    add_header Access-Control-Allow-Credentials false always;
+
     location /v1/api {
         proxy_pass http://lenny_api:1337/v1/api;
         proxy_set_header Host $host;
@@ -27,9 +33,9 @@ server {
     }
     
     location /read {
-	proxy_pass http://lenny_reader:3000/read;
-	proxy_set_header Host $http_host;
-	proxy_set_header X-Real-IP $remote_addr;
+    proxy_pass http://lenny_reader:3000/read;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         sub_filter_types text/html text/css application/javascript application/json;
@@ -40,9 +46,9 @@ server {
     }
 
     location /read/ {
-	proxy_pass http://lenny_reader:3000$request_uri;
-	proxy_set_header Host $http_host;
-	proxy_set_header X-Real-IP $remote_addr;
+    proxy_pass http://lenny_reader:3000$request_uri;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }


### PR DESCRIPTION
This pull request introduces configuration changes to the Nginx server to support cross-origin requests, which is important for enabling communication between the BookServer/Cloudflare and your API. The main update is the addition of CORS headers.

**Nginx configuration updates for CORS support:**

* Added `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers`, and `Access-Control-Allow-Credentials` headers to the Nginx server block in `docker/nginx/conf.d/lenny.conf` to allow cross-origin requests from any origin and support various HTTP methods.