### PR TITLE
Fix OPDS media type to application/opds-publication+json

### DIFF
--- a/lenny/routes/api.py
+++ b/lenny/routes/api.py
@@ -106,7 +106,7 @@ async def get_opds(request: Request, book_id:int):
         content=json.dumps(
             LennyAPI.opds_feed(olid=book_id)
         ),
-        media_type="application/opds+json"
+        media_type="application/opds-publication+json"
     )
 
 # Redirect to the Thorium Web Reader


### PR DESCRIPTION
This pull request makes a minor update to the media type used in the OPDS API response. The change ensures the response uses the correct OPDS publication media type for better standards compliance.