### PR TITLE
Nginx rate limiting

### DIFF
--- a/docker/nginx/conf.d/lenny.conf
+++ b/docker/nginx/conf.d/lenny.conf
@@ -12,7 +12,37 @@ server {
     add_header Access-Control-Allow-Headers "Content-Type, Authorization" always;
     add_header Access-Control-Allow-Credentials false always;
 
+    # OPDS endpoints without rate limiting
+    location ~ ^/v1/api/opds {
+        proxy_pass http://lenny_api:1337;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    
+    # Items endpoint without rate limiting
+    location = /v1/api/items {
+        proxy_pass http://lenny_api:1337/v1/api;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    
+    # Strict rate limiting for sensitive endpoints
+    location ~ ^/v1/api/(upload|authenticate) {
+        limit_req zone=strict_limit burst=5 nodelay;
+        proxy_pass http://lenny_api:1337;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    
+    # General API endpoints with standard rate limiting
     location /v1/api {
+        limit_req zone=general_limit burst=10 nodelay;
         proxy_pass http://lenny_api:1337/v1/api;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/docker/nginx/conf.d/lenny.conf
+++ b/docker/nginx/conf.d/lenny.conf
@@ -23,7 +23,7 @@ server {
     
     # Items endpoint without rate limiting
     location = /v1/api/items {
-        proxy_pass http://lenny_api:1337/v1/api;
+        proxy_pass http://lenny_api:1337;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -15,6 +15,17 @@ http {
     sendfile        on;
     keepalive_timeout  65;
     client_max_body_size 50M;
+    
+    # Rate limiting zones
+    # General zone: 100 requests per minute (1.67 req/sec) with burst of 10
+    limit_req_zone $binary_remote_addr zone=general_limit:10m rate=100r/m;
+    
+    # Lenient zone for OPDS endpoints: 300 requests per minute (5 req/sec) with burst of 20
+    limit_req_zone $binary_remote_addr zone=lenient_limit:10m rate=300r/m;
+    
+    # Strict zone for sensitive endpoints: 20 requests per minute (0.33 req/sec) with burst of 5
+    limit_req_zone $binary_remote_addr zone=strict_limit:10m rate=20r/m;
+    
     include /etc/nginx/conf.d/*.conf;
 }
 

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -20,7 +20,7 @@ http {
     # General zone: 100 requests per minute (1.67 req/sec) with burst of 10
     limit_req_zone $binary_remote_addr zone=general_limit:10m rate=100r/m;
     
-    # Lenient zone for OPDS endpoints: 300 requests per minute (5 req/sec) with burst of 20
+    # Lenient zone reserved for future use: 300 requests per minute (5 req/sec) with burst of 20
     limit_req_zone $binary_remote_addr zone=lenient_limit:10m rate=300r/m;
     
     # Strict zone for sensitive endpoints: 20 requests per minute (0.33 req/sec) with burst of 5


### PR DESCRIPTION
## NGINX Rate Limiter

Implements rate limiting using Nginx `limit_req` to block high-volume or burst traffic before it reaches FastAPI, protecting the API from overloaded repeated attacks.

### Key Features

- **Edge Protection**: Nginx blocks excessive requests at the edge before they reach FastAPI
- **Endpoint-Specific Limits**: 
  - OPDS endpoints: No rate limiting 
  - `/items`: No rate limiting 
  - `/upload` & `/authenticate`: Strict (20/min + 5 burst)
  - Other endpoints: General (100/min + 10 burst)
- **Burst Handling**: Allows controlled bursts with `nodelay` for better user experience

### Changes

**Nginx Configuration** (`docker/nginx/nginx.conf`):
- Added 3 `limit_req_zone` definitions:
  - `general_limit`: 100 requests/minute
  - `lenient_limit`: 300 requests/minute (defined but reserved for future use)
  - `strict_limit`: 20 requests/minute

**Nginx Location Blocks** (`docker/nginx/conf.d/lenny.conf`):
- `/v1/api/opds*` → No rate limiting (regex location)
- `/v1/api/items` → No rate limiting (exact match)
- `/v1/api/(upload|authenticate)` → Strict rate limiting (20/min)
- `/v1/api/*` (all other endpoints) → General rate limiting (100/min)
- Fixed regex location blocks to use `proxy_pass` without URI path (Nginx requirement)

### Rate Limiting Strategy

1. **No Rate Limiting**:
   - `/v1/api/opds` and `/v1/api/opds/{book_id}` - Public catalog feeds for e-reader apps
   - `/v1/api/items` - Public items listing

2. **Strict Rate Limiting** (20/min + 5 burst = 25 total):
   - `/v1/api/upload` - File uploads (resource-intensive)
   - `/v1/api/authenticate` - Authentication (security-sensitive)

3. **General Rate Limiting** (100/min + 10 burst = 110 total):
   - All other API endpoints

### Testing Results

**OPDS endpoints**: 20/20 requests passed (no rate limiting)  
**/items endpoint**: 20/20 requests passed (no rate limiting)  
**General endpoints**: 11 requests passed, then 503 (rate limited)  
**Strict endpoints**: 8 requests passed, then 503 (rate limited)

### Verification

- Nginx configuration valid: 
- Rate limit zones configured: 3 zones 
- Location blocks correctly applied: 
- Edge protection working: 

### Technical Details

**Nginx Location Matching Order**:
1. Exact matches (`=`)
2. Regex matches (`~`) - in order of appearance
3. Prefix matches - longest match first

This ensures OPDS and `/items` endpoints are matched before general rate limiting is applied.

**Burst Handling**:
- `burst=N`: Allows N additional requests beyond the rate
- `nodelay`: Processes burst requests immediately instead of queuing

### Notes

- Rate limiting is implemented entirely at the Nginx layer (no application-level rate limiting)
- The `lenient_limit` zone (300/min) is defined but not currently used; reserved for future endpoint-specific needs
- All rate limiting uses `$binary_remote_addr` as the key (client IP address)

PTAL @ronibhakta1 