### PR TITLE
Fix CORS nginx + fastapi for OPTIONS to enable OAuth2 Implicit

### DIFF
--- a/docker/nginx/conf.d/lenny.conf
+++ b/docker/nginx/conf.d/lenny.conf
@@ -6,12 +6,6 @@ server {
     error_log /var/log/nginx/error.log debug;
     access_log /var/log/nginx/access.log;
 
-    # CORS headers to allow BookServer / Cloudflare requests
-    add_header Access-Control-Allow-Origin * always;
-    add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS" always;
-    add_header Access-Control-Allow-Headers "Content-Type, Authorization" always;
-    add_header Access-Control-Allow-Credentials false always;
-
     location /v1/api {
         proxy_pass http://lenny_api:1337/v1/api;
         proxy_set_header Host $host;

--- a/lenny/app.py
+++ b/lenny/app.py
@@ -18,13 +18,10 @@ app = FastAPI(
 # conflict with CORS handled by nginx
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:3000",
-        "http://127.0.0.1:3000"
-    ],
+    allow_origin_regex=".*",
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type"],
 )
 
 app.templates = Jinja2Templates(directory="lenny/templates")


### PR DESCRIPTION
This pull request updates how Cross-Origin Resource Sharing (CORS) is handled in the application by shifting CORS configuration from the Nginx proxy layer to the FastAPI application layer. The changes tighten the allowed HTTP methods and headers, and remove CORS headers from the Nginx configuration.

**CORS configuration changes:**

* Removed all CORS-related headers from the Nginx configuration in `docker/nginx/conf.d/lenny.conf`, so Nginx no longer manages CORS for API requests.
* Updated the FastAPI `CORSMiddleware` configuration in `lenny/app.py` to:
  - Allow all origins using a regular expression.
  - Restrict allowed HTTP methods to `GET` and `OPTIONS`.
  - Restrict allowed headers to `Authorization` and `Content-Type`.
  - Continue allowing credentials.