### PR TITLE
fix: Update OAuth redirect URLs to use query parameters instead of fragments

### DIFF
--- a/lenny/routes/api.py
+++ b/lenny/routes/api.py
@@ -447,7 +447,7 @@ async def oauth_authorize(
         state = state or body.get("state")
         
         fragment = LennyAPI.build_oauth_fragment(session, state)
-        return RedirectResponse(url=f"{redirect_uri}#{urlencode(fragment)}", status_code=303)
+        return RedirectResponse(url=f"{redirect_uri}?{urlencode(fragment)}", status_code=303)
 
     client_ip = request.client.host
     body = await LennyAPI.parse_request_body(request)
@@ -498,7 +498,7 @@ async def oauth_authorize(
             response = request.app.templates.TemplateResponse("oauth_success.html", success_context)
         else:
             response = RedirectResponse(
-                url=f"{current_redirect_uri}#{urlencode(fragment)}",
+                url=f"{current_redirect_uri}?{urlencode(fragment)}",
                 status_code=303
             )
         


### PR DESCRIPTION
This pull request makes a small but important change to the OAuth authorization flow in `lenny/routes/api.py`. The redirect URLs used after authorization are now constructed with query parameters instead of URL fragments, which improves compatibility with OAuth clients and allows the server to handle the parameters more reliably.

* OAuth Redirect URL Construction:
  * Changed the redirect URLs in the `oauth_authorize` function to use query parameters (`?`) instead of fragments (`#`) when passing the OAuth fragment. [[1]](diffhunk://#diff-c850c1516b1be232d38a31c91cf176bded69d6c27f1556977097e60961196cc1L450-R450) [[2]](diffhunk://#diff-c850c1516b1be232d38a31c91cf176bded69d6c27f1556977097e60961196cc1L501-R501)