### PR TITLE
fix: Update OAuth redirect to use fragment identifier for token data

### DIFF
--- a/lenny/core/api.py
+++ b/lenny/core/api.py
@@ -472,9 +472,7 @@ class LennyAPI:
     @classmethod
     def build_oauth_fragment(cls, session_cookie: str, state: str = None) -> dict:
         """Build OAuth token fragment for redirect URL or opds:// callback."""
-        auth_doc_id = quote(LennyAPI.make_url("/v1/api/oauth/implicit"), safe='')
         fragment = {
-            "id": auth_doc_id,
             "access_token": session_cookie,
             "token_type": "bearer",
             "expires_in": auth.COOKIE_TTL

--- a/lenny/routes/api.py
+++ b/lenny/routes/api.py
@@ -447,7 +447,7 @@ async def oauth_authorize(
         state = state or body.get("state")
         
         fragment = LennyAPI.build_oauth_fragment(session, state)
-        return RedirectResponse(url=f"{redirect_uri}?{urlencode(fragment)}", status_code=303)
+        return RedirectResponse(url=f"{redirect_uri}#{urlencode(fragment)}", status_code=303)
 
     client_ip = request.client.host
     body = await LennyAPI.parse_request_body(request)
@@ -498,7 +498,7 @@ async def oauth_authorize(
             response = request.app.templates.TemplateResponse("oauth_success.html", success_context)
         else:
             response = RedirectResponse(
-                url=f"{current_redirect_uri}?{urlencode(fragment)}",
+                url=f"{current_redirect_uri}#{urlencode(fragment)}",
                 status_code=303
             )
         


### PR DESCRIPTION
This pull request updates the OAuth redirect behavior to use URL fragments instead of query parameters when returning tokens to clients. This change improves security and aligns with OAuth best practices for implicit grant flows.

OAuth redirect changes:

* Updated both successful and regular OAuth authorization redirects to append the token fragment after a `#` (fragment) instead of a `?` (query), ensuring tokens are not exposed in server logs or browser history. (`lenny/routes/api.py`) [[1]](diffhunk://#diff-c850c1516b1be232d38a31c91cf176bded69d6c27f1556977097e60961196cc1L450-R450) [[2]](diffhunk://#diff-c850c1516b1be232d38a31c91cf176bded69d6c27f1556977097e60961196cc1L501-R501)
* Removed the unused `auth_doc_id` field from the OAuth fragment and simplified the fragment construction. (`lenny/core/api.py`)