### PR TITLE
Set the logging level for httpx, httpcore, hpack, and multipart to WARNING. Docker logs are sanitized. 

### DIFF
--- a/lenny/core/auth.py
+++ b/lenny/core/auth.py
@@ -15,6 +15,11 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("httpcore").setLevel(logging.WARNING)
+logging.getLogger("hpack").setLevel(logging.WARNING)
+logging.getLogger("multipart").setLevel(logging.WARNING)
+
 ATTEMPT_LIMIT = 5
 ATTEMPT_WINDOW_SECONDS = 60
 SERIALIZER = None  # Will be initialized lazily


### PR DESCRIPTION
This pull request makes a small change to improve logging behavior in the authentication module. It sets the log level for several third-party libraries to `WARNING` to reduce unnecessary log output.

* Reduced log verbosity by setting the log level to `WARNING` for `httpx`, `httpcore`, `hpack`, and `multipart` libraries in `lenny/core/auth.py`.