### PR TITLE
Debian related fixes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,31 +2,29 @@
 set -e
 echo "Welcome to Lenny Installer for Mac & Linux"
 
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    OS="linux"
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-    OS="mac"
-else
-    echo "[!] Only Mac & Linux supported, detected: $OSTYPE"
-    exit 1
-fi
+OS_NAME="$(uname -s)"
+case "$OS_NAME" in
+  Linux*) OS="linux" ;;
+  Darwin*) OS="mac" ;;
+  *) echo "[!] Only Mac & Linux supported, detected: $OS_NAME"; exit 1 ;;
+esac
 
 if [ "$OS" = "linux" ]; then
   echo "[+] Updating package index (apt)..."
   sudo apt update -y
 
-  if ! require make; then
+  if ! command -v make >/dev/null 2>&1; then
     echo "[+] Installing build-essential (make, gcc, etc.)..."
     sudo apt install -y build-essential bc
   fi
 
-  if ! require curl; then
+  if ! command -v curl >/dev/null 2>&1; then
     echo "[+] Installing curl..."
     sudo apt install -y curl
   fi
 fi
 
-if [[ ! -d "lenny" ]]; then
+if [ ! -d "lenny" ]; then
   echo "[+] Downloading Lenny source code..."
   mkdir -p lenny
   curl -L https://github.com/ArchiveLabs/lenny/archive/refs/heads/main.tar.gz | tar -xz --strip-components=1 -C lenny
@@ -35,34 +33,39 @@ fi
 
 # TODO: Switch to docker/utils/docker_helpers
 wait_for_docker_ready() {
-    echo "[+] Waiting up to 1 minute for Docker to start..."
-    for i in {1..10}; do
-	docker info >/dev/null 2>&1 && { echo "[+] Docker ready, beginning Lenny install."; break; }
-	echo "Waiting for Docker ($i/10)..."
-	sleep 6
-	[[ $i -eq 10 ]] && { echo "Error: Docker not ready after 1 minute."; exit 1; }
-    done
+  echo "[+] Waiting up to 1 minute for Docker to start..."
+  i=1
+  while [ $i -le 10 ]; do
+    docker info >/dev/null 2>&1 && { echo "[+] Docker ready, beginning Lenny install."; break; }
+    echo "Waiting for Docker ($i/10)..."
+    sleep 6
+    i=$((i + 1))
+    if [ $i -gt 10 ]; then
+      echo "Error: Docker not ready after 1 minute."
+      exit 1
+    fi
+  done
 }
 
 if ! command -v docker >/dev/null 2>&1; then
-    echo "[+] Installing `docker` to build Lenny..."
-    if [ "$OS" == "mac" ]; then	
-	if ! command -v brew >/dev/null 2>&1; then
-	    echo "[+] Installing Homebrew to get docker..."
-	    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-	fi
-	echo "[+] Installing Docker Desktop via Homebrew..."
-	brew install --cask docker
-	echo "[+] Loading docker..."
-	open -a Docker
-	echo "[+] Waiting for docker to start..."
-	wait_for_docker_ready
-    elif [ "$OS" == "linux" ]; then
-	curl -fsSL https://get.docker.com | sh && sudo usermod -aG docker "$USER"
-	sudo systemctl start docker
-	sudo systemctl enable docker
+  echo "[+] Installing docker to build Lenny..."
+  if [ "$OS" = "mac" ]; then
+    if ! command -v brew >/dev/null 2>&1; then
+      echo "[+] Installing Homebrew to get docker..."
+      /bin/sh -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     fi
+    echo "[+] Installing Docker Desktop via Homebrew..."
+    brew install --cask docker
+    echo "[+] Loading docker..."
+    open -a Docker
+    echo "[+] Waiting for docker to start..."    
     wait_for_docker_ready
+  elif [ "$OS" = "linux" ]; then
+    curl -fsSL https://get.docker.com | sh && sudo usermod -aG docker "$USER"
+    sudo systemctl start docker
+    sudo systemctl enable docker
+    wait_for_docker_ready
+  fi
 fi
 
 cd lenny
@@ -71,6 +74,5 @@ sudo make tunnel configure rebuild
 
 echo "[+] Starting preload step (with allocated TTY)..."
 sudo script -q -c "make preload" /dev/null
-
 
 echo "[✓] Lenny installation complete!"


### PR DESCRIPTION
This pull request makes small fixes to the installation script, it replaces it's non-Posix compliant parts with alternatives.

**Summary of changes**
- Changes the OS detection to work on debian, which uses dash. Running the script currently gives errors like:- `[[: not found`.
- Replaces the for loop which uses `{1..10}`, which is not supported by dash, with a while loop.
- Also removes `require` which does not seem to be defined anywhere.
- Also removes the second accidental call to `wait_for_docker_ready` for the Mac case