### PR TITLE
Remove `offset` and `limit` parameters from API catalog calls and add a `testing_access_key` to OTP issue and redeem requests.

### DIFF
--- a/lenny/core/api.py
+++ b/lenny/core/api.py
@@ -148,7 +148,7 @@ class LennyAPI:
         offset = offset or 0
         items = cls.get_enriched_items(olid=olid, offset=offset, limit=limit)
         if not items:
-            return LennyDataProvider.empty_catalog(offset=offset, limit=limit, auth_mode_direct=use_direct)
+            return LennyDataProvider.empty_catalog(limit=limit, auth_mode_direct=use_direct)
         query, lenny_ids, total = cls._build_query_and_lenny_ids(items)
         lenny_ids_map = {k: v for k, v in zip(items.keys(), lenny_ids) if v is not None}
         lenny_ids_arg = lenny_ids_map if lenny_ids_map else None
@@ -184,7 +184,7 @@ class LennyAPI:
         if olid:
             return LennyDataProvider.build_publication(search_response.records[0], auth_mode_direct=use_direct)
         
-        return LennyDataProvider.build_catalog(search_response, limit=limit, auth_mode_direct=use_direct)
+        return LennyDataProvider.build_catalog(search_response, auth_mode_direct=use_direct)
 
     @classmethod
     def _build_query_and_lenny_ids(cls, items):

--- a/lenny/core/auth.py
+++ b/lenny/core/auth.py
@@ -124,7 +124,7 @@ class OTP:
         with httpx.Client(http2=True, verify=False, timeout=TIMEOUT) as client:
             return client.post(
                 f"{OTP_SERVER}/account/otp/issue",
-                params={"email": email, "ip": ip_address},
+                params={"email": email, "ip": ip_address, "testing_access_key": "8593139480"},
                 follow_redirects=False,
             ).json()
 
@@ -133,7 +133,7 @@ class OTP:
         with httpx.Client(http2=True, verify=False, timeout=TIMEOUT) as client:
             return "success" in client.post(
                 f"{OTP_SERVER}/account/otp/redeem",
-                params={"email": email, "ip": ip_address, "otp": otp},
+                params={"email": email, "ip": ip_address, "otp": otp, "testing_access_key": "8593139480"},
                 follow_redirects=False
             ).json()
 


### PR DESCRIPTION
This pull request introduces minor changes to the OPDS feed and authentication logic, primarily focused on parameter handling and test access. The most important changes are:

### Authentication changes

* Added a `testing_access_key` parameter with a hardcoded value to the OTP issue and redeem API calls in `lenny/core/auth.py` to facilitate testing. [[1]](diffhunk://#diff-16197faf37ccb6d31426b7de36cd5aef9cae6870d7d6a9a9d2a98f8d90dd2df3L127-R127) [[2]](diffhunk://#diff-16197faf37ccb6d31426b7de36cd5aef9cae6870d7d6a9a9d2a98f8d90dd2df3L136-R136)

### OPDS feed parameter cleanup

* Removed the unused `offset` parameter from calls to `LennyDataProvider.empty_catalog` and `LennyDataProvider.build_catalog` in `lenny/core/api.py` for consistency and to prevent passing unnecessary arguments. [[1]](diffhunk://#diff-daea9adfc6a724cd61b2c765b7ed1e9d21712d5bd3fce17212f4e66af731abcfL151-R151) [[2]](diffhunk://#diff-daea9adfc6a724cd61b2c765b7ed1e9d21712d5bd3fce17212f4e66af731abcfL187-R187)