### PR TITLE
feat(auth): optional IA S3 auth plugin for patron borrow requests

### DIFF
--- a/lenny/configs/__init__.py
+++ b/lenny/configs/__init__.py
@@ -39,6 +39,7 @@ OL_S3_SECRET_KEY = os.environ.get('OL_S3_SECRET_KEY') or None
 OL_USERNAME = os.environ.get('OL_USERNAME') or None
 LENDING_ENABLED = os.environ.get('LENNY_LENDING_ENABLED', 'false').lower() == 'true'
 OL_INDEXED = os.environ.get('LENNY_OL_INDEXED', 'false').lower() == 'true'
+IA_AUTH_ENABLED = os.environ.get('IA_AUTH_ENABLED', 'false').lower() == 'true'
 
 READER_PORT = int(os.environ.get('READER_PORT', 3000))
 READIUM_PORT = int(os.environ.get('READIUM_PORT', 15080))
@@ -83,4 +84,5 @@ S3_CONFIG = {
 
 __all__ = ['SCHEME', 'HOST', 'PORT', 'DEBUG', 'OPTIONS', 'DB_URI', 'DB_CONFIG', 'S3_CONFIG', 'TESTING',
            'ADMIN_USERNAME', 'ADMIN_PASSWORD', 'ADMIN_INTERNAL_SECRET', 'ADMIN_SALT',
-           'OL_S3_ACCESS_KEY', 'OL_S3_SECRET_KEY', 'OL_USERNAME', 'LENDING_ENABLED', 'OL_INDEXED']
+           'OL_S3_ACCESS_KEY', 'OL_S3_SECRET_KEY', 'OL_USERNAME', 'LENDING_ENABLED', 'OL_INDEXED',
+           'IA_AUTH_ENABLED']

--- a/lenny/core/auth.py
+++ b/lenny/core/auth.py
@@ -119,6 +119,36 @@ def verify_session_cookie(session, client_ip: str = None):
             return data
     except BadSignature:
         return None
+
+
+IA_S3_CHECK_URL = "https://s3.us.archive.org"
+
+
+async def verify_ia_s3_keys(access_key: str, secret_key: str) -> Optional[str]:
+    """Validate IA S3 keys and return patron email (screenname@archive.org) or None.
+
+    Uses the internetarchive library's S3 session (same auth stack as the ia CLI)
+    to call s3.us.archive.org?check_auth=1 — a public S3 endpoint, not xauthn.
+    The blocking network call is offloaded to a thread so the event loop is not blocked.
+    """
+    import asyncio
+
+    def _check_sync() -> Optional[str]:
+        try:
+            import internetarchive as ia
+            session = ia.get_session({"s3": {"access": access_key, "secret": secret_key}})
+            r = session.get(IA_S3_CHECK_URL, params={"check_auth": "1"})
+            if r.status_code == 200:
+                data = r.json()
+                if data.get("authorized"):
+                    username = data.get("username") or data.get("screenname")
+                    if username:
+                        return f"{username}@archive.org"
+        except Exception:
+            pass
+        return None
+
+    return await asyncio.to_thread(_check_sync)
         
 class OTP:
 

--- a/lenny/routes/api.py
+++ b/lenny/routes/api.py
@@ -31,6 +31,7 @@ from fastapi.responses import (
     JSONResponse,
 )
 from lenny.core import auth
+from lenny.core.auth import verify_ia_s3_keys
 from lenny.core.api import LennyAPI
 from lenny.core import ol_bootstrap
 from lenny.core.cache import Cache
@@ -239,7 +240,20 @@ async def borrow_item(request: Request, response: Response, book_id: int, format
 
     session = extract_session(request, session)
     email = get_authenticated_email(request, session)
-    
+    ia_session_cookie = None
+
+    # IA S3 auth plugin: when enabled, accept Authorization: LOW access:secret from patrons.
+    if not email and configs.IA_AUTH_ENABLED:
+        auth_header = request.headers.get("Authorization", "")
+        parts = auth_header.split(None, 1)  # split on any whitespace, limit 1
+        if len(parts) == 2 and parts[0].upper() == "LOW" and ":" in parts[1]:
+            ia_access, ia_secret = parts[1].split(":", 1)
+            ia_access, ia_secret = ia_access.strip(), ia_secret.strip()
+            if ia_access and ia_secret:
+                email = await verify_ia_s3_keys(ia_access, ia_secret)
+                if email:
+                    ia_session_cookie = auth.create_session_cookie(email, request.client.host)
+
     if email:
         try:
             loan = item.borrow(email)
@@ -249,17 +263,20 @@ async def borrow_item(request: Request, response: Response, book_id: int, format
              raise HTTPException(status_code=409, detail="No copies available for borrowing")
         except Exception as e:
             raise HTTPException(status_code=400, detail=str(e))
-        
-        if is_direct_mode:
-            return RedirectResponse(
-                url=f"/v1/api/items/{book_id}/read", 
-                status_code=303
-            )
 
-        return Response(
-            content=json.dumps(build_post_borrow_publication(book_id, auth_mode_direct=is_direct_mode)),
-            media_type="application/opds-publication+json"
-        )
+        if is_direct_mode:
+            borrow_resp = RedirectResponse(url=f"/v1/api/items/{book_id}/read", status_code=303)
+        else:
+            borrow_resp = Response(
+                content=json.dumps(build_post_borrow_publication(book_id, auth_mode_direct=is_direct_mode)),
+                media_type="application/opds-publication+json"
+            )
+        if ia_session_cookie:
+            borrow_resp.set_cookie(
+                key="session", value=ia_session_cookie, max_age=auth.COOKIE_TTL,
+                httponly=True, secure=True, samesite="Lax", path="/"
+            )
+        return borrow_resp
     
     if not is_direct_mode:
           return JSONResponse(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -71,3 +71,53 @@ def test_otp_authenticate_with_ip():
         
         # Should fail with wrong IP
         assert auth.verify_session_cookie(session_cookie, "10.0.0.2") is None
+
+
+import asyncio
+import unittest.mock as mock
+
+
+class TestVerifyIaS3Keys:
+    """Tests for verify_ia_s3_keys() — mocks internetarchive.get_session to avoid real network calls."""
+
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def _make_session(self, status_code, json_data):
+        response = mock.MagicMock()
+        response.status_code = status_code
+        response.json.return_value = json_data
+        session = mock.MagicMock()
+        session.get.return_value = response
+        return session
+
+    def test_valid_keys_return_email(self):
+        session = self._make_session(200, {"authorized": True, "username": "testuser"})
+        with mock.patch("internetarchive.get_session", return_value=session):
+            result = self._run(auth.verify_ia_s3_keys("goodaccess", "goodsecret"))
+        assert result == "testuser@archive.org"
+
+    def test_screenname_fallback_when_no_username(self):
+        session = self._make_session(200, {"authorized": True, "username": "", "screenname": "fallbackuser"})
+        with mock.patch("internetarchive.get_session", return_value=session):
+            result = self._run(auth.verify_ia_s3_keys("access", "secret"))
+        assert result == "fallbackuser@archive.org"
+
+    def test_unauthorized_returns_none(self):
+        session = self._make_session(200, {"authorized": False, "error": "invalid key"})
+        with mock.patch("internetarchive.get_session", return_value=session):
+            result = self._run(auth.verify_ia_s3_keys("bad", "keys"))
+        assert result is None
+
+    def test_non_200_returns_none(self):
+        session = self._make_session(403, {})
+        with mock.patch("internetarchive.get_session", return_value=session):
+            result = self._run(auth.verify_ia_s3_keys("bad", "keys"))
+        assert result is None
+
+    def test_network_error_returns_none(self):
+        session = mock.MagicMock()
+        session.get.side_effect = Exception("connection refused")
+        with mock.patch("internetarchive.get_session", return_value=session):
+            result = self._run(auth.verify_ia_s3_keys("access", "secret"))
+        assert result is None

--- a/tests/test_direct_auth_mock.py
+++ b/tests/test_direct_auth_mock.py
@@ -246,3 +246,89 @@ def test_opds_links_oauth_mode():
      assert "/items/1/borrow" in borrow_links[0].href
      assert borrow_links[0].properties.get("authenticate") is not None
 
+
+# --- IA S3 auth plugin tests ---
+
+def test_ia_auth_disabled_ignores_low_header(mock_auth, mock_item_exists, monkeypatch):
+    """When IA_AUTH_ENABLED=False, LOW headers are ignored and falls through to OPDS 401."""
+    import lenny.configs as conf
+    import lenny.routes.api as routes
+    from unittest.mock import AsyncMock
+
+    mock_auth.return_value = None
+    monkeypatch.setattr(conf, "IA_AUTH_ENABLED", False)
+    monkeypatch.setattr(conf, "AUTH_MODE_DIRECT", False)
+    mock_verify = AsyncMock(return_value="testuser@archive.org")
+    monkeypatch.setattr(routes, "verify_ia_s3_keys", mock_verify)
+
+    response = client.get(
+        "/v1/api/items/123/borrow",
+        headers={"Authorization": "LOW validaccess:validsecret"},
+    )
+    assert response.status_code == 401
+    mock_verify.assert_not_called()
+
+
+def test_ia_auth_enabled_valid_keys_creates_loan_and_sets_cookie(mock_auth, mock_item_exists, monkeypatch):
+    """When IA_AUTH_ENABLED=True and valid LOW keys, loan is created and session cookie is set."""
+    import lenny.configs as conf
+    import lenny.routes.api as routes
+    import lenny.core.auth as core_auth
+    from unittest.mock import AsyncMock
+
+    mock_auth.return_value = None
+    monkeypatch.setattr(conf, "IA_AUTH_ENABLED", True)
+    monkeypatch.setattr(conf, "AUTH_MODE_DIRECT", False)  # oauth mode → 200 OPDS publication
+    mock_verify = AsyncMock(return_value="testuser@archive.org")
+    monkeypatch.setattr(routes, "verify_ia_s3_keys", mock_verify)
+    monkeypatch.setattr(core_auth, "create_session_cookie", lambda email, ip=None: "dummy-session-token")
+
+    response = client.get(
+        "/v1/api/items/123/borrow",
+        headers={"Authorization": "LOW goodaccess:goodsecret"},
+    )
+    assert response.status_code == 200
+    assert "session" in response.cookies
+    mock_verify.assert_called_once_with("goodaccess", "goodsecret")
+
+
+def test_ia_auth_enabled_invalid_keys_falls_through_to_otp(mock_auth, mock_item_exists, monkeypatch):
+    """When IA_AUTH_ENABLED=True but keys are invalid, falls through to unauthenticated flow."""
+    import lenny.configs as conf
+    import lenny.routes.api as routes
+    from unittest.mock import AsyncMock
+
+    mock_auth.return_value = None
+    monkeypatch.setattr(conf, "IA_AUTH_ENABLED", True)
+    monkeypatch.setattr(conf, "AUTH_MODE_DIRECT", False)
+    mock_verify = AsyncMock(return_value=None)
+    monkeypatch.setattr(routes, "verify_ia_s3_keys", mock_verify)
+
+    response = client.get(
+        "/v1/api/items/123/borrow",
+        headers={"Authorization": "LOW badaccess:badsecret"},
+    )
+    assert response.status_code == 401  # falls through to OPDS 401
+
+
+def test_ia_auth_case_insensitive_low_scheme(mock_auth, mock_item_exists, monkeypatch):
+    """Header scheme 'low' (lowercase) is accepted."""
+    import lenny.configs as conf
+    import lenny.routes.api as routes
+    import lenny.core.auth as core_auth
+    from unittest.mock import AsyncMock
+
+    mock_auth.return_value = None
+    monkeypatch.setattr(conf, "IA_AUTH_ENABLED", True)
+    monkeypatch.setattr(conf, "AUTH_MODE_DIRECT", False)
+    mock_verify = AsyncMock(return_value="testuser@archive.org")
+    monkeypatch.setattr(routes, "verify_ia_s3_keys", mock_verify)
+    monkeypatch.setattr(core_auth, "create_session_cookie", lambda email, ip=None: "dummy-session-token")
+
+    response = client.get(
+        "/v1/api/items/123/borrow",
+        headers={"Authorization": "low goodaccess:goodsecret"},
+    )
+    assert response.status_code == 200
+    mock_verify.assert_called_once_with("goodaccess", "goodsecret")
+


### PR DESCRIPTION
## Summary

Closes #183

Adds an optional IA auth plugin that allows a logged-out patron to borrow a book by supplying their Internet Archive S3 credentials as an `Authorization: LOW <access>:<secret>` HTTP header. When valid, Lenny creates the loan and sets a session cookie — bypassing the OTP flow entirely.

Opt-in: only Lenny instances that set `IA_AUTH_ENABLED=true` in their environment will use this plugin. All other instances are unaffected.

## Changes

**`lenny/configs/__init__.py`**
- New `IA_AUTH_ENABLED` env var (default `false`)

**`lenny/core/auth.py`**
- New async `verify_ia_s3_keys(access, secret) -> Optional[str]` — validates credentials using `internetarchive.get_session()` against `https://s3.us.archive.org?check_auth=1` (the same auth stack as the `ia` CLI; no privileged access required). Returns `{username}@archive.org` or `None`. The blocking network call is offloaded via `asyncio.to_thread`.

**`lenny/routes/api.py`**
- In `borrow_item()`, before the session-cookie check: if `IA_AUTH_ENABLED` and the request carries `Authorization: LOW access:secret` (parsed case-insensitively, any whitespace), validate via `verify_ia_s3_keys()`. On success, create loan + IP-bound session cookie in one step.

## Flow

```
POST /v1/api/items/{id}/borrow
  Authorization: LOW <ia_access>:<ia_secret>
  ↓
verify_ia_s3_keys() → internetarchive session → s3.us.archive.org?check_auth=1
  ↓ success
patron email = {username}@archive.org
  ↓
item.borrow(email) → loan created
  ↓
response: loan publication + Set-Cookie: session=... (IP-bound)
```

## Why This Matters

The Internet Archive Labs Lenny instance hosts purchased EPUBs for OL patrons. IA patrons already have S3 keys. This plugin lets them borrow directly without going through the OTP email flow, while keeping the OTP path as the default for all other Lenny instances.

## Companion PR

- <a href="https://github.com/internetarchive/openlibrary/pull/12841">internetarchive/openlibrary#12841</a> — OL side: require valid IA S3 keys on OTP service endpoints

## Test Plan

- [ ] `IA_AUTH_ENABLED=false` (default): borrow endpoint behaviour unchanged, LOW header ignored
- [ ] `IA_AUTH_ENABLED=true`, no Authorization header: falls through to OTP flow as before
- [ ] `IA_AUTH_ENABLED=true`, `Authorization: LOW valid:keys`: loan created, session cookie set in response
- [ ] `IA_AUTH_ENABLED=true`, `Authorization: LOW bad:keys`: `verify_ia_s3_keys()` returns `None`, falls through to OTP
- [ ] Existing session cookie auth still works when `IA_AUTH_ENABLED=true`
- [ ] `Authorization: low valid:keys` (lowercase scheme): accepted identically to `LOW`