### PR TITLE
chore: add prune target to clean up dangling images and cap build cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,17 @@ url:
 update:
 	@bash docker/utils/update.sh
 
+# Remove dangling images and cap build cache to free disk/memory.
+# Safe: never touches running containers, named volumes, or DB data.
+# Run manually after updates or whenever disk usage is high.
+.PHONY: prune
+prune:
+	@echo "Pruning dangling images..."
+	@docker image prune -f
+	@echo "Capping build cache to 2 GB..."
+	@docker builder prune -f --reserved-space=2gb
+	@echo "Done."
+
 # Log in to archive.org/openlibrary.org and store IA S3 keys in .env.
 # Idempotent — safe to re-run. Use to log in, re-login with a different account,
 # or recover from a failed lending setup.

--- a/docker/lenny-app/Dockerfile
+++ b/docker/lenny-app/Dockerfile
@@ -11,7 +11,7 @@ RUN corepack enable
 # Changing this value invalidates the build cache from this line onward —
 # deterministic on both BuildKit and the classic builder — so `make update`
 # re-clones and checks out the new commit. No floating HEAD = no surprise drift.
-ARG LENNY_APP_REF=ab430e1ef3bb23441943cc2f62b2c5e526f95913
+ARG LENNY_APP_REF=3226f048d7ac2e7ecc4c84239bb7de4f0ce7242e
 
 RUN git clone https://github.com/ArchiveLabs/lenny-app . && \
     git checkout "$LENNY_APP_REF"

--- a/docker/utils/update/040_build_and_restart.sh
+++ b/docker/utils/update/040_build_and_restart.sh
@@ -31,13 +31,5 @@ if ! $COMPOSE_CMD -p "$LENNY_COMPOSE_PROJECT" build admin; then
     echo ""
 fi
 
-# Prune dangling images (old untagged builds). Safe: never touches named volumes,
-# running containers, or BuildKit cache mounts (pnpm_store etc.).
-# Builder cache capped at 2 GB — preserves pnpm/pip layer caches that make
-# future builds fast while preventing unbounded disk growth.
-echo "Pruning dangling images and capping build cache..."
-docker image prune -f || true
-docker builder prune -f --reserved-space=2gb || true
-
 # Restart all services
 $COMPOSE_CMD -p "$LENNY_COMPOSE_PROJECT" up -d


### PR DESCRIPTION
This pull request introduces improvements to how Docker image and build cache cleanup is handled in the development workflow. The main change is moving the disk cleanup steps from an automatic part of the update script to a new, manually-invoked Makefile target, making cleanup safer and more intentional. Additionally, the `lenny-app` dependency is updated to a new commit.

**Docker image and build cache management:**

* Added a new `.PHONY` `prune` target to the `Makefile` that prunes dangling Docker images and caps the build cache to 2 GB. This operation is now manual, making it safer and preventing unintentional cleanup during automated updates.
* Removed automatic pruning of dangling images and build cache from the `docker/utils/update/040_build_and_restart.sh` script, so these actions are no longer performed on every update.

**Dependency update:**

* Updated the `LENNY_APP_REF` in `docker/lenny-app/Dockerfile` to point to a new commit (`3226f048d7ac2e7ecc4c84239bb7de4f0ce7242e`).